### PR TITLE
Automate daily reporting workflow for logistics control tower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
+!.env.example
 .env*
 
 # vercel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2025-03-17
+
+### Added
+- Automated daily reporting pipeline with Slack and Resend delivery helpers.
+- `/api/report` endpoint combining vessel, marine, and briefing data with marine snapshot summary.
+- node-cron scheduler script for self-hosted deployments and Vercel cron definitions.
+- Dashboard badge tooltip plus manual “Send Daily Report” control with event feed logging.
+
+### Changed
+- `/api/health` now surfaces last report metadata for UI consumption.
+- Updated documentation and environment template for new integrations.
+
+### Fixed
+- Health badge no longer leaves stale text when API errors occur; report failures are highlighted as warnings.

--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server"
+
+import { deriveVoyageIoi } from "@/lib/server/ioi"
+import { VESSEL_DATASET } from "@/lib/server/vessel-data"
+
+const LOWER_PROMPT_MATCH = [
+  { key: "weather", handler: buildWeatherInsight },
+  { key: "risk", handler: buildRiskInsight },
+  { key: "schedule", handler: buildRiskInsight },
+]
+
+export async function POST(request: Request) {
+  const form = await request.formData()
+  const prompt = String(form.get("prompt") ?? "").trim()
+  const model = String(form.get("model") ?? "gpt-4.1-mini")
+  const attachments = form
+    .getAll("files")
+    .map((item) => (item instanceof File ? item : null))
+    .filter((file): file is File => Boolean(file))
+
+  if (!prompt) {
+    return NextResponse.json({ answer: "질문을 입력해주세요." })
+  }
+
+  const lower = prompt.toLowerCase()
+  const handler = LOWER_PROMPT_MATCH.find((entry) => lower.includes(entry.key))?.handler
+  const body = handler ? handler(prompt) : buildDefaultInsight(prompt)
+
+  const attachmentLine = attachments.length
+    ? `\n첨부 ${attachments.length}건: ${attachments.map((file) => file.name || "무제").join(", ")}`
+    : ""
+
+  return NextResponse.json({
+    answer: `${body}\n모델: ${model}${attachmentLine}`,
+  })
+}
+
+function buildWeatherInsight(_prompt: string) {
+  const tz = VESSEL_DATASET.timezone
+  const lines = VESSEL_DATASET.weatherWindows.map((window) => {
+    const start = new Date(window.start)
+    const end = new Date(window.end)
+    const span = `${start.toLocaleString("ko-KR", { timeZone: tz, hour: "2-digit", minute: "2-digit", month: "short", day: "numeric" })}` +
+      ` – ${end.toLocaleString("ko-KR", { timeZone: tz, hour: "2-digit", minute: "2-digit", month: "short", day: "numeric" })}`
+    return `• ${span} · Hs ${window.wave_m.toFixed(2)} m · Wind ${window.wind_kt.toFixed(2)} kt · ${window.summary}`
+  })
+
+  return [
+    "📡 최신 기상 창 요약",
+    ...lines,
+    "- 2.10 m 이상 파고 구간에서는 야간 창구 대기 6시간 확보",
+    "- Warn 창에는 보조 예비 항로를 준비하세요.",
+  ].join("\n")
+}
+
+function buildRiskInsight(_prompt: string) {
+  const tz = VESSEL_DATASET.timezone
+  const voyages = VESSEL_DATASET.schedule.map((voyage) => ({
+    voyage,
+    ioi: deriveVoyageIoi(voyage),
+  }))
+  const rows = voyages.map(({ voyage, ioi }) => {
+    const bucket = ioi >= 75 ? "GO" : ioi >= 55 ? "WATCH" : "NO-GO"
+    const etd = new Date(voyage.etd).toLocaleString("ko-KR", { timeZone: tz, hour: "2-digit", minute: "2-digit", month: "short", day: "numeric" })
+    const eta = new Date(voyage.eta).toLocaleString("ko-KR", { timeZone: tz, hour: "2-digit", minute: "2-digit", month: "short", day: "numeric" })
+    return `• ${voyage.id}: ${bucket} (${ioi.toFixed(0)} IOI) · ${etd} → ${eta}`
+  })
+  return [
+    "🧭 IOI 및 스케줄 상태",
+    ...rows,
+    "- WATCH 이상 항차는 출항 6시간 전 현장 기상 재확인",
+    "- NO-GO 항차는 Delay 24h 액션을 통해 자동 보류 가능합니다.",
+  ].join("\n")
+}
+
+function buildDefaultInsight(prompt: string) {
+  return `요청하신 내용("${prompt}")에 대해 추가 정보가 필요합니다. 스케줄, 기상, 위험 중 하나를 지정해 주세요.`
+}

--- a/app/api/briefing/route.ts
+++ b/app/api/briefing/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server"
+
+import { deriveVoyageIoi } from "@/lib/server/ioi"
+import { WeatherWindowRecord } from "@/lib/server/vessel-data"
+
+type IncomingVoyage = {
+  id: string
+  cargo: string
+  etd: string
+  eta: string
+  status: string
+  origin?: string
+  destination?: string
+}
+
+type BriefingPayload = {
+  current_time?: string
+  vessel_name?: string
+  vessel_status?: string
+  current_voyage?: string | null
+  schedule?: IncomingVoyage[]
+  weather_windows?: WeatherWindowRecord[]
+  model?: string
+}
+
+function safeDate(value?: string | null) {
+  if (!value) return null
+  const d = new Date(value)
+  return Number.isNaN(d.valueOf()) ? null : d
+}
+
+function formatLocal(value: Date, tz: string) {
+  return value.toLocaleString("ko-KR", {
+    timeZone: tz,
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
+}
+
+function summariseWeather(windows: WeatherWindowRecord[], tz: string) {
+  if (!windows.length) {
+    return "- 기상 경고 없음"
+  }
+  return windows
+    .map((window) => {
+      const start = safeDate(window.start)
+      const end = safeDate(window.end)
+      const span = start && end ? `${formatLocal(start, tz)} – ${formatLocal(end, tz)}` : "시간 미정"
+      return `- ${span}: Hs ${window.wave_m.toFixed(2)} m · Wind ${window.wind_kt.toFixed(2)} kt · ${window.summary}`
+    })
+    .join("\n")
+}
+
+export async function POST(request: Request) {
+  const payload = (await request.json().catch(() => ({}))) as BriefingPayload
+  const tz = "Asia/Dubai"
+  const now = safeDate(payload.current_time ?? null) ?? new Date()
+  const schedule = (payload.schedule ?? []).map((item) => ({
+    ...item,
+    etd: safeDate(item.etd) ?? new Date(item.etd ?? now.toISOString()),
+    eta: safeDate(item.eta) ?? new Date(item.eta ?? now.toISOString()),
+  }))
+
+  const sorted = schedule.sort((a, b) => a.etd.valueOf() - b.etd.valueOf())
+  const active =
+    sorted.find((voyage) => now >= voyage.etd && now <= voyage.eta) ??
+    sorted.find((voyage) => voyage.id === payload.current_voyage) ??
+    sorted[0]
+
+  const headline = `${payload.vessel_name ?? "선박"} · 상태: ${payload.vessel_status ?? "N/A"}`
+  const voyageLine = active
+    ? `진행 항차: ${active.id} (${active.cargo}) · ETD ${formatLocal(active.etd, tz)} · ETA ${formatLocal(active.eta, tz)}`
+    : "진행 중인 항차가 없습니다."
+
+  const riskLines = sorted
+    .slice(0, 3)
+    .map((voyage) => {
+      const synthetic = {
+        ...voyage,
+        swellFt: 3.28084,
+        windKt: 15,
+      }
+      const ioi = deriveVoyageIoi(synthetic as any)
+      const bucket = ioi >= 75 ? "GO" : ioi >= 55 ? "WATCH" : "NO-GO"
+      return `• ${voyage.id}: ${bucket} (${ioi.toFixed(0)} IOI) – ${formatLocal(voyage.etd, tz)} / ${formatLocal(voyage.eta, tz)}`
+    })
+    .join("\n")
+
+  const weather = summariseWeather(payload.weather_windows ?? [], tz)
+
+  const briefing = [
+    headline,
+    `현재 시각: ${formatLocal(now, tz)}`,
+    voyageLine,
+    "\n[Top 3 IOI]",
+    riskLines,
+    "\n[Weather Windows]",
+    weather,
+    "\n권장 조치:",
+    "- 승무원과 하역팀에 최신 일정 공유",
+    "- 야간 기상 창 감시 유지",
+    "- Risk Scan 버튼으로 6시간마다 재평가",
+  ].join("\n")
+
+  return NextResponse.json({ briefing })
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+
+import { getLastReport } from "@/lib/server/report-state"
+
+export async function GET() {
+  const report = getLastReport()
+  const status = report && !report.ok ? "degraded" : "ok"
+
+  return NextResponse.json({
+    status,
+    timestamp: new Date().toISOString(),
+    report,
+  })
+}

--- a/app/api/marine/route.ts
+++ b/app/api/marine/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server"
+
+import { computeIoiFromMarine } from "@/lib/server/ioi"
+import { VESSEL_DATASET } from "@/lib/server/vessel-data"
+
+interface CachedMarine {
+  snapshot: {
+    hs: number | null
+    windKt: number | null
+    swellPeriod: number | null
+    ioi: number | null
+    fetchedAt: string
+  }
+  expiresAt: number
+}
+
+const cache = new Map<string, CachedMarine>()
+const CACHE_TTL_MS = 10 * 60 * 1000
+const FETCH_TIMEOUT_MS = 7 * 1000
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const port = searchParams.get("port") ?? VESSEL_DATASET.vessel.port
+  const coords = VESSEL_DATASET.ports[port]
+
+  if (!coords) {
+    return NextResponse.json({ error: "Unknown port" }, { status: 400 })
+  }
+
+  const cached = cache.get(port)
+  const now = Date.now()
+  if (cached && cached.expiresAt > now) {
+    return NextResponse.json({ port, coords, ...cached.snapshot, cached: true })
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    const params = new URLSearchParams({
+      latitude: String(coords.lat),
+      longitude: String(coords.lon),
+      hourly: ["wave_height", "wind_speed_10m", "swell_wave_period"].join(","),
+      timezone: "auto",
+    })
+    const response = await fetch(`https://marine-api.open-meteo.com/v1/marine?${params.toString()}`, {
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Marine API responded ${response.status}`)
+    }
+
+    const payload = await response.json()
+    const hs = Number(payload?.hourly?.wave_height?.[0] ?? null)
+    const windMs = Number(payload?.hourly?.wind_speed_10m?.[0] ?? null)
+    const swellPeriod = Number(payload?.hourly?.swell_wave_period?.[0] ?? null)
+    const windKt = Number.isFinite(windMs) ? windMs * 1.94384 : null
+
+    const ioi = computeIoiFromMarine({ hs, windKt, swellPeriod })
+
+    const snapshot = {
+      hs: Number.isFinite(hs) ? hs : null,
+      windKt: Number.isFinite(windKt) ? windKt : null,
+      swellPeriod: Number.isFinite(swellPeriod) ? swellPeriod : null,
+      ioi,
+      fetchedAt: new Date().toISOString(),
+    }
+
+    cache.set(port, {
+      snapshot,
+      expiresAt: now + CACHE_TTL_MS,
+    })
+
+    return NextResponse.json({ port, coords, ...snapshot, cached: false })
+  } catch (error) {
+    if (cached) {
+      return NextResponse.json({ port, coords, ...cached.snapshot, stale: true }, { status: 200 })
+    }
+    const message = error instanceof Error ? error.message : "Unknown marine error"
+    return NextResponse.json({ error: message }, { status: 502 })
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/app/api/report/route.test.ts
+++ b/app/api/report/route.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { GET } from "./route"
+import { sendEmail, sendSlack } from "@/lib/server/notifier"
+import { clearLastReport, getLastReport } from "@/lib/server/report-state"
+import { VESSEL_DATASET } from "@/lib/server/vessel-data"
+
+vi.mock("@/lib/server/notifier", () => ({
+  sendSlack: vi.fn(),
+  sendEmail: vi.fn(),
+}))
+
+const vesselResponse = {
+  timezone: VESSEL_DATASET.timezone,
+  vessel: VESSEL_DATASET.vessel,
+  schedule: VESSEL_DATASET.schedule,
+  weatherWindows: VESSEL_DATASET.weatherWindows,
+}
+
+const briefingResponse = {
+  briefing: "Headline\nLine 2",
+}
+
+function buildMarineResponse() {
+  return {
+    hs: 1.23,
+    windKt: 18.5,
+    ioi: 74,
+    fetchedAt: new Date().toISOString(),
+  }
+}
+
+describe("/api/report", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2025-03-17T02:00:00Z"))
+    process.env.REPORT_TIMEZONE = "Asia/Dubai"
+    clearLastReport()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetAllMocks()
+    vi.unstubAllGlobals()
+    clearLastReport()
+  })
+
+  function stubFetchSequence(options?: { skipMarine?: boolean }) {
+    const marinePayload = options?.skipMarine ? null : buildMarineResponse()
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes("/api/vessel")) {
+        return new Response(JSON.stringify(vesselResponse), { status: 200 })
+      }
+      if (url.includes("/api/marine")) {
+        if (!marinePayload) {
+          return new Response("error", { status: 500 })
+        }
+        return new Response(JSON.stringify(marinePayload), { status: 200 })
+      }
+      if (url.includes("/api/briefing")) {
+        return new Response(JSON.stringify(briefingResponse), { status: 200 })
+      }
+      return new Response("not found", { status: 404 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    return { fetchMock, marinePayload }
+  }
+
+  it("returns ok when both channels succeed", async () => {
+    const { marinePayload } = stubFetchSequence()
+    vi.mocked(sendSlack).mockResolvedValue({ channel: "slack", ok: true, status: 200 })
+    vi.mocked(sendEmail).mockResolvedValue({ channel: "email", ok: true, status: 202 })
+
+    const response = await GET(new Request("https://example.com/api/report?slot=am"))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.slot).toBe("am")
+    expect(body.sample).toContain("[Marine Snapshot]")
+    if (marinePayload) {
+      expect(body.sample).toContain(marinePayload.hs.toFixed(2))
+    }
+    const stored = getLastReport()
+    expect(stored?.ok).toBe(true)
+    expect(stored?.slot).toBe("am")
+  })
+
+  it("flags partial success when email fails", async () => {
+    stubFetchSequence()
+    vi.mocked(sendSlack).mockResolvedValue({ channel: "slack", ok: true, status: 200 })
+    vi.mocked(sendEmail).mockResolvedValue({ channel: "email", ok: false, status: 500, error: "boom" })
+
+    const response = await GET(new Request("https://example.com/api/report?slot=pm"))
+    const body = await response.json()
+
+    expect(body.ok).toBe(true)
+    expect(body.sent).toHaveLength(2)
+    const emailResult = body.sent.find((item: any) => item.channel === "email")
+    expect(emailResult.ok).toBe(false)
+    expect(emailResult.error).toBe("boom")
+  })
+
+  it("falls back when marine snapshot is unavailable", async () => {
+    stubFetchSequence({ skipMarine: true })
+    vi.mocked(sendSlack).mockResolvedValue({ channel: "slack", ok: true })
+    vi.mocked(sendEmail).mockResolvedValue({ channel: "email", ok: true })
+
+    const response = await GET(new Request("https://example.com/api/report"))
+    const body = await response.json()
+
+    expect(body.ok).toBe(true)
+    expect(body.sample).toContain("[Marine Snapshot] n/a")
+  })
+})

--- a/app/api/report/route.ts
+++ b/app/api/report/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from "next/server"
+
+import { sendEmail, sendSlack, type ChannelResult } from "@/lib/server/notifier"
+import { getLastReport, setLastReport } from "@/lib/server/report-state"
+import { VESSEL_DATASET } from "@/lib/server/vessel-data"
+
+const DEFAULT_TIMEZONE = process.env.REPORT_TIMEZONE ?? VESSEL_DATASET.timezone
+
+type Slot = "am" | "pm"
+
+type MarineSnapshot = {
+  hs: number | null
+  windKt: number | null
+  ioi: number | null
+  fetchedAt?: string
+}
+
+type VesselPayload = {
+  timezone: string
+  vessel: typeof VESSEL_DATASET.vessel
+  schedule: Array<typeof VESSEL_DATASET.schedule[number] & { ioi?: number }>
+  weatherWindows: typeof VESSEL_DATASET.weatherWindows
+}
+
+type BriefingResponse = {
+  briefing?: string
+}
+
+function mapScheduleItem(voyage: (typeof VESSEL_DATASET.schedule)[number]) {
+  return {
+    ...voyage,
+    swellFt: voyage.swellFt,
+    windKt: voyage.windKt,
+  }
+}
+
+function parseSlot(value: string | null): Slot | null {
+  if (!value) return null
+  return value === "am" || value === "pm" ? value : null
+}
+
+function determineSlot(date: Date, timezone: string): Slot {
+  const formatter = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    hour12: false,
+    timeZone: timezone,
+  })
+  const parts = formatter.formatToParts(date)
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0")
+  return hour < 12 ? "am" : "pm"
+}
+
+function formatLocal(date: Date, timezone: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date)
+}
+
+async function fetchJson<T>(url: URL, init?: RequestInit): Promise<T | null> {
+  try {
+    const response = await fetch(url, init)
+    if (!response.ok) {
+      return null
+    }
+    return (await response.json()) as T
+  } catch (error) {
+    console.error("report.fetch", url.toString(), error)
+    return null
+  }
+}
+
+function buildMarineSummary(snapshot: MarineSnapshot | null) {
+  if (!snapshot) {
+    return "[Marine Snapshot] n/a"
+  }
+  const hs = snapshot.hs != null ? snapshot.hs.toFixed(2) : "--"
+  const wind = snapshot.windKt != null ? snapshot.windKt.toFixed(2) : "--"
+  const ioi = snapshot.ioi != null ? snapshot.ioi.toFixed(0) : "n/a"
+  return `[Marine Snapshot] Hs ${hs} m · Wind ${wind} kt · IOI ${ioi}`
+}
+
+function summariseChannels(results: ChannelResult[]) {
+  return results.map((result) => ({
+    channel: result.channel,
+    ok: result.ok,
+    status: result.status,
+    id: result.id,
+    error: result.error,
+    skipped: result.skipped ?? false,
+  }))
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url)
+  const slot = parseSlot(requestUrl.searchParams.get("slot"))
+  const vesselUrl = new URL("/api/vessel", requestUrl.origin)
+  const vesselPayload = (await fetchJson<VesselPayload>(vesselUrl)) ?? {
+    timezone: VESSEL_DATASET.timezone,
+    vessel: VESSEL_DATASET.vessel,
+    schedule: VESSEL_DATASET.schedule.map(mapScheduleItem),
+    weatherWindows: VESSEL_DATASET.weatherWindows,
+  }
+  const timezone = vesselPayload.timezone ?? DEFAULT_TIMEZONE
+  const now = new Date()
+  const effectiveSlot = slot ?? determineSlot(now, timezone)
+
+  const marineUrl = new URL("/api/marine", requestUrl.origin)
+  marineUrl.searchParams.set("port", vesselPayload.vessel.port)
+  const marinePayload = (await fetchJson<MarineSnapshot>(marineUrl)) ?? null
+
+  const briefingUrl = new URL("/api/briefing", requestUrl.origin)
+  const briefingPayload = await fetchJson<BriefingResponse>(briefingUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      current_time: now.toISOString(),
+      vessel_name: vesselPayload.vessel.name,
+      vessel_status: vesselPayload.vessel.status,
+      current_voyage: vesselPayload.schedule[0]?.id ?? null,
+      schedule: vesselPayload.schedule,
+      weather_windows: vesselPayload.weatherWindows,
+    }),
+  })
+
+  const marineSummary = buildMarineSummary(marinePayload)
+  const briefing = briefingPayload?.briefing ?? `${vesselPayload.vessel.name} briefing unavailable.`
+  const combined = `${briefing}\n\n${marineSummary}`
+
+  const subject = `[Logistics] Daily briefing (${effectiveSlot.toUpperCase()}) – ${formatLocal(now, timezone)} (${timezone})`
+
+  const slackResult = await sendSlack(combined)
+  const emailResult = await sendEmail({
+    subject,
+    text: combined,
+  })
+
+  const sent = [slackResult, emailResult]
+  const ok = sent.some((result) => result.ok)
+  const previous = getLastReport()
+  const record = {
+    generatedAt: now.toISOString(),
+    slot: effectiveSlot,
+    ok,
+    sent: summariseChannels(sent),
+    sample: combined,
+    timezone,
+  }
+  setLastReport(record)
+
+  return NextResponse.json({
+    ok,
+    slot: effectiveSlot,
+    generatedAt: record.generatedAt,
+    timezone,
+    sent: record.sent,
+    sample: combined,
+    previous,
+  })
+}

--- a/app/api/vessel/actions/route.ts
+++ b/app/api/vessel/actions/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+
+const ACTION_MESSAGES: Record<string, string> = {
+  "quick-go": "선장이 즉시 출항을 승인했습니다.",
+  "delay-24h": "항차가 24시간 연기되었습니다.",
+  recalculate: "최신 기상 정보를 반영하여 경로를 재계산했습니다.",
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+  const action = String(body?.action ?? "")
+  if (!action || !(action in ACTION_MESSAGES)) {
+    return NextResponse.json({ error: "Unsupported action" }, { status: 400 })
+  }
+
+  const timestamp = new Date().toISOString()
+  return NextResponse.json({
+    ok: true,
+    action,
+    message: ACTION_MESSAGES[action],
+    timestamp,
+  })
+}

--- a/app/api/vessel/route.ts
+++ b/app/api/vessel/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server"
+
+import { deriveVoyageIoi } from "@/lib/server/ioi"
+import { VESSEL_DATASET } from "@/lib/server/vessel-data"
+
+export async function GET() {
+  const voyages = VESSEL_DATASET.schedule.map((voyage) => ({
+    ...voyage,
+    ioi: deriveVoyageIoi(voyage),
+  }))
+
+  return NextResponse.json({
+    timezone: VESSEL_DATASET.timezone,
+    vessel: VESSEL_DATASET.vessel,
+    route: VESSEL_DATASET.route,
+    schedule: voyages,
+    weatherWindows: VESSEL_DATASET.weatherWindows,
+    ports: VESSEL_DATASET.ports,
+    events: VESSEL_DATASET.events,
+    serverTime: new Date().toISOString(),
+  })
+}

--- a/lib/server/ioi.ts
+++ b/lib/server/ioi.ts
@@ -1,0 +1,56 @@
+import { VoyageRecord } from "./vessel-data"
+
+export interface MarineSnapshot {
+  hs?: number | null
+  windKt?: number | null
+  swellPeriod?: number | null
+  ioi?: number | null
+}
+
+const HS_CAUTION = 1.5
+const HS_NOGO = 2.5
+const WIND_CAUTION = 18
+const WIND_NOGO = 28
+const SWELL_MIN = 6
+const SWELL_MAX = 12
+
+export function computeIoiFromMarine(snapshot: MarineSnapshot): number | null {
+  const hs = snapshot.hs ?? null
+  const wind = snapshot.windKt ?? null
+  const period = snapshot.swellPeriod ?? null
+
+  const hsScore =
+    hs === null || Number.isNaN(hs)
+      ? 0.5
+      : hs <= HS_CAUTION
+        ? 1
+        : hs >= HS_NOGO
+          ? 0
+          : 1 - (hs - HS_CAUTION) / (HS_NOGO - HS_CAUTION)
+
+  const windScore =
+    wind === null || Number.isNaN(wind)
+      ? 0.5
+      : wind <= WIND_CAUTION
+        ? 1
+        : wind >= WIND_NOGO
+          ? 0
+          : 1 - (wind - WIND_CAUTION) / (WIND_NOGO - WIND_CAUTION)
+
+  const boundedPeriod = Math.min(SWELL_MAX, Math.max(SWELL_MIN, period ?? 8))
+  const swellScore = (boundedPeriod - SWELL_MIN) / (SWELL_MAX - SWELL_MIN)
+
+  const combined = 0.5 * hsScore + 0.35 * windScore + 0.15 * swellScore
+  const ioi = Math.round(combined * 100)
+  return Math.max(0, Math.min(100, ioi))
+}
+
+export function deriveVoyageIoi(voyage: VoyageRecord): number {
+  const hs = voyage.swellFt / 3.28084
+  const snapshot: MarineSnapshot = {
+    hs,
+    windKt: voyage.windKt,
+    swellPeriod: 8,
+  }
+  return computeIoiFromMarine(snapshot) ?? 50
+}

--- a/lib/server/notifier.test.ts
+++ b/lib/server/notifier.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { sendEmail, sendSlack } from "./notifier"
+
+const originalEnv = { ...process.env }
+
+describe("notifier", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.env = { ...originalEnv }
+  })
+
+  describe("sendSlack", () => {
+    it("returns skipped when webhook is missing", async () => {
+      const result = await sendSlack("hello", { webhookUrl: undefined })
+      expect(result.ok).toBe(false)
+      expect(result.skipped).toBe(true)
+      expect(result.error).toContain("Slack webhook")
+    })
+
+    it("succeeds when webhook responds 200", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+      vi.stubGlobal("fetch", mockFetch)
+
+      const result = await sendSlack("hello", { webhookUrl: "https://example.com" })
+
+      expect(result.ok).toBe(true)
+      expect(result.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("bubbles up response errors", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response("bad", { status: 500, statusText: "error" }),
+      )
+      vi.stubGlobal("fetch", mockFetch)
+
+      const result = await sendSlack("hello", { webhookUrl: "https://example.com" })
+
+      expect(result.ok).toBe(false)
+      expect(result.status).toBe(500)
+      expect(result.error).toContain("bad")
+    })
+  })
+
+  describe("sendEmail", () => {
+    beforeEach(() => {
+      process.env.RESEND_API_KEY = "test-key"
+      process.env.REPORT_SENDER = "no-reply@example.com"
+      process.env.REPORT_RECIPIENTS = "ops@example.com"
+    })
+
+    it("reports missing API key", async () => {
+      delete process.env.RESEND_API_KEY
+      const result = await sendEmail({ subject: "hi", text: "body" })
+      expect(result.ok).toBe(false)
+      expect(result.skipped).toBe(true)
+      expect(result.error).toContain("Resend API key")
+    })
+
+    it("reports missing recipients", async () => {
+      process.env.REPORT_RECIPIENTS = ""
+      const result = await sendEmail({ subject: "hi", text: "body" })
+      expect(result.ok).toBe(false)
+      expect(result.error).toContain("recipients")
+    })
+
+    it("returns metadata on success", async () => {
+      const payload = { id: "email-123" }
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(payload), { status: 202 }))
+      vi.stubGlobal("fetch", mockFetch)
+
+      const result = await sendEmail({ subject: "hi", text: "body" })
+
+      expect(result.ok).toBe(true)
+      expect(result.id).toBe("email-123")
+      expect(result.status).toBe(202)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("captures API errors", async () => {
+      const payload = { message: "failure" }
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(payload), { status: 500 }))
+      vi.stubGlobal("fetch", mockFetch)
+
+      const result = await sendEmail({ subject: "oops", text: "body" })
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toContain("failure")
+      expect(result.status).toBe(500)
+    })
+  })
+})

--- a/lib/server/notifier.ts
+++ b/lib/server/notifier.ts
@@ -1,0 +1,166 @@
+const DEFAULT_TIMEOUT_MS = 8000
+
+export interface ChannelResult {
+  channel: "slack" | "email"
+  ok: boolean
+  status?: number
+  id?: string
+  error?: string
+  skipped?: boolean
+}
+
+export interface SlackOptions {
+  webhookUrl?: string
+  timeoutMs?: number
+  username?: string
+}
+
+export async function sendSlack(
+  message: string,
+  options: SlackOptions = {},
+): Promise<ChannelResult> {
+  const webhookUrl = options.webhookUrl ?? process.env.SLACK_WEBHOOK_URL
+  if (!webhookUrl) {
+    return {
+      channel: "slack",
+      ok: false,
+      skipped: true,
+      error: "Slack webhook not configured",
+    }
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+
+  try {
+    const payload = {
+      text: message,
+      username: options.username ?? "Logistics Control Tower",
+    }
+
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+
+    const ok = response.ok
+    const status = response.status
+
+    if (!ok) {
+      const text = await response.text().catch(() => "")
+      return {
+        channel: "slack",
+        ok: false,
+        status,
+        error: text || `Slack responded with ${status}`,
+      }
+    }
+
+    return {
+      channel: "slack",
+      ok: true,
+      status,
+    }
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : "Unknown Slack error"
+    return {
+      channel: "slack",
+      ok: false,
+      error: messageText,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export interface EmailOptions {
+  apiKey?: string
+  sender?: string
+  recipients?: string[]
+  subject: string
+  text: string
+  timeoutMs?: number
+}
+
+export async function sendEmail(options: EmailOptions): Promise<ChannelResult> {
+  const apiKey = options.apiKey ?? process.env.RESEND_API_KEY
+  const sender = options.sender ?? process.env.REPORT_SENDER
+  const recipients = options.recipients ?? (process.env.REPORT_RECIPIENTS?.split(/[,\n]/).map((value) => value.trim()).filter(Boolean) ?? [])
+
+  if (!apiKey) {
+    return {
+      channel: "email",
+      ok: false,
+      skipped: true,
+      error: "Resend API key not configured",
+    }
+  }
+
+  if (!sender) {
+    return {
+      channel: "email",
+      ok: false,
+      error: "Report sender address missing",
+    }
+  }
+
+  if (!recipients.length) {
+    return {
+      channel: "email",
+      ok: false,
+      error: "Report recipients missing",
+    }
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from: sender,
+        to: recipients,
+        subject: options.subject,
+        text: options.text,
+      }),
+      signal: controller.signal,
+    })
+
+    const status = response.status
+    const payload = await response.json().catch(() => ({})) as { id?: string; message?: string }
+
+    if (!response.ok) {
+      return {
+        channel: "email",
+        ok: false,
+        status,
+        error: payload?.message ?? `Resend responded with ${status}`,
+      }
+    }
+
+    return {
+      channel: "email",
+      ok: true,
+      status,
+      id: payload?.id,
+    }
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : "Unknown email error"
+    return {
+      channel: "email",
+      ok: false,
+      error: messageText,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/lib/server/report-state.ts
+++ b/lib/server/report-state.ts
@@ -1,0 +1,24 @@
+import type { ChannelResult } from "./notifier"
+
+export interface ReportRecord {
+  generatedAt: string
+  slot: "am" | "pm"
+  ok: boolean
+  sent: ChannelResult[]
+  sample: string
+  timezone: string
+}
+
+let lastReport: ReportRecord | null = null
+
+export function setLastReport(record: ReportRecord) {
+  lastReport = record
+}
+
+export function getLastReport(): ReportRecord | null {
+  return lastReport
+}
+
+export function clearLastReport() {
+  lastReport = null
+}

--- a/lib/server/vessel-data.ts
+++ b/lib/server/vessel-data.ts
@@ -1,0 +1,151 @@
+export interface VoyageRecord {
+  id: string
+  cargo: string
+  etd: string
+  eta: string
+  status: "Scheduled" | "Delayed" | "In Transit" | "Completed"
+  origin: string
+  destination: string
+  swellFt: number
+  windKt: number
+}
+
+export interface WeatherWindowRecord {
+  start: string
+  end: string
+  wave_m: number
+  wind_kt: number
+  vis_km: number
+  summary: string
+}
+
+export interface EventRecord {
+  timestamp: string
+  level: "info" | "warn" | "error"
+  message: string
+}
+
+export interface VesselDataset {
+  timezone: string
+  vessel: {
+    name: string
+    imo: string
+    mmsi: string
+    readiness: string
+    status: string
+    port: string
+  }
+  route: Array<[number, number]>
+  schedule: VoyageRecord[]
+  weatherWindows: WeatherWindowRecord[]
+  ports: Record<string, { lat: number; lon: number }>
+  events: EventRecord[]
+}
+
+export const VESSEL_DATASET: VesselDataset = {
+  timezone: "Asia/Dubai",
+  vessel: {
+    name: "JOPETWIL 71",
+    imo: "9582829",
+    mmsi: "470486000",
+    readiness: "Ready @ MW4",
+    status: "Ready @ MW4",
+    port: "Jebel Ali",
+  },
+  route: [
+    [24.3400, 54.4500],
+    [24.4300, 54.4300],
+    [24.4700, 54.3900],
+    [24.5600, 54.2000],
+    [24.6500, 54.0000],
+    [24.8500, 53.8000],
+    [24.9500, 53.7400],
+    [24.9500, 53.3000],
+    [25.0200, 53.0600],
+    [24.8400, 53.6500],
+  ],
+  schedule: [
+    {
+      id: "69th",
+      cargo: "Dune Sand",
+      etd: "2025-09-28T16:00:00Z",
+      eta: "2025-09-29T04:00:00Z",
+      status: "Scheduled",
+      origin: "MW4",
+      destination: "AGI",
+      swellFt: 6.1,
+      windKt: 18.0,
+    },
+    {
+      id: "70th",
+      cargo: "10mm Agg.",
+      etd: "2025-09-30T16:00:00Z",
+      eta: "2025-10-01T04:00:00Z",
+      status: "Scheduled",
+      origin: "MW4",
+      destination: "AGI",
+      swellFt: 4.3,
+      windKt: 14.8,
+    },
+    {
+      id: "71st",
+      cargo: "5mm Agg.",
+      etd: "2025-10-02T16:00:00Z",
+      eta: "2025-10-03T04:00:00Z",
+      status: "Scheduled",
+      origin: "MW4",
+      destination: "AGI",
+      swellFt: 3.2,
+      windKt: 11.6,
+    },
+  ],
+  weatherWindows: [
+    {
+      start: "2025-09-28T12:00:00Z",
+      end: "2025-09-29T06:00:00Z",
+      wave_m: 2.10,
+      wind_kt: 26.0,
+      vis_km: 6.4,
+      summary: "모래폭풍 가능성 – 야간 입항 지연 권고",
+    },
+    {
+      start: "2025-09-30T00:00:00Z",
+      end: "2025-10-01T08:00:00Z",
+      wave_m: 1.45,
+      wind_kt: 18.2,
+      vis_km: 9.1,
+      summary: "잔잔한 북서풍 – 정상 창",
+    },
+    {
+      start: "2025-10-02T08:00:00Z",
+      end: "2025-10-03T12:00:00Z",
+      wave_m: 0.95,
+      wind_kt: 12.3,
+      vis_km: 11.0,
+      summary: "양호 – 예비 창",
+    },
+  ],
+  ports: {
+    "Jebel Ali": { lat: 25.006, lon: 55.065 },
+    "Khor Fakkan": { lat: 25.3391, lon: 56.3644 },
+    "Ras Al Khaimah": { lat: 25.7895, lon: 55.9428 },
+    Singapore: { lat: 1.3521, lon: 103.8198 },
+  },
+  events: [
+    {
+      timestamp: "2025-09-28T12:05:00Z",
+      level: "info",
+      message: "시뮬레이터 부팅 – 해상 관측 연결됨",
+    },
+    {
+      timestamp: "2025-09-28T12:10:00Z",
+      level: "info",
+      message: "CSV 스케줄 3건 로드",
+    },
+    {
+      timestamp: "2025-09-28T12:15:00Z",
+      level: "warn",
+      message: "69th 항차 야간 창구 혼잡 예보",
+    },
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -49,6 +51,7 @@
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "^0.4.6",
+    "node-cron": "^4.2.1",
     "react": "^19",
     "react-day-picker": "9.8.0",
     "react-dom": "^19",
@@ -66,9 +69,11 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^3.2.4",
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan
+
+## Objectives
+- Provide automated briefing distribution via Slack and email, using marine and vessel data snapshots.
+- Add a daily reporting API and background scheduler for both Vercel (cron) and self-hosted deployments.
+- Surface report delivery status within the logistics dashboard and document the required environment configuration.
+
+## Steps
+1. **Messaging utilities**
+   - Create `lib/server/notifier.ts` with Slack webhook and Resend email helpers, including error normalization.
+   - Add unit tests with mocked fetch to validate success/error paths and coverage.
+
+2. **Reporting API**
+   - Implement `/api/report` GET handler to compose vessel, marine, and briefing data, append marine summary, and dispatch via notifier.
+   - Handle optional `slot` query, partial failures, and return structured JSON with timestamps.
+   - Extend `/api/health` if necessary to expose last report metadata for the dashboard badge.
+
+3. **Scheduling & state**
+   - Add `scripts/scheduler.ts` for node-cron self-host execution with timezone-aware scheduling and lock protection.
+   - Provide Vercel cron definitions in `vercel.json` and persist last-report metadata (in-memory fallback) for badge display.
+
+4. **Frontend integration**
+   - Update `public/logistics-app.html` script to read new health/report status fields, trigger manual report refresh, and render tooltips.
+
+5. **Documentation & config**
+   - Create `.env.example` with notifier variables, update README with deployment and scheduling guidance, and append CHANGELOG entry.
+   - Add instructions for running tests (`pnpm test`, coverage) and scheduler usage.
+
+6. **Verification**
+   - Run linting/typing/test commands available in the project (eslint, prettier, tsc, vitest) and capture results for the final report.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
       react:
         specifier: ^19
         version: 19.0.0
@@ -174,6 +177,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.0.0
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1))
       postcss:
         specifier: ^8.5
         version: 8.5.0
@@ -186,6 +192,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.0.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1)
 
 packages:
 
@@ -197,15 +206,192 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
 
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -332,9 +518,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -399,6 +593,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -1056,6 +1254,116 @@ packages:
   '@radix-ui/rect@1.1.0':
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
+  '@rollup/rollup-android-arm-eabi@4.52.3':
+    resolution: {integrity: sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.3':
+    resolution: {integrity: sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.3':
+    resolution: {integrity: sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.3':
+    resolution: {integrity: sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.3':
+    resolution: {integrity: sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.3':
+    resolution: {integrity: sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.3':
+    resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.3':
+    resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.3':
+    resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.3':
+    resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.3':
+    resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.3':
+    resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.3':
+    resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.3':
+    resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.3':
+    resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.3':
+    resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.3':
+    resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.3':
+    resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.3':
+    resolution: {integrity: sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.3':
+    resolution: {integrity: sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.3':
+    resolution: {integrity: sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.3':
+    resolution: {integrity: sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==}
+    cpu: [x64]
+    os: [win32]
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -1150,6 +1458,9 @@ packages:
   '@tailwindcss/postcss@4.1.9':
     resolution: {integrity: sha512-v3DKzHibZO8ioVDmuVHCW1PR0XSM7nS40EjZFJEA1xPuvTuQPaR5flE1LyikU3hu2u1KNWBtEaSe8qsQjX3tyg==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1177,6 +1488,12 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@22.0.0':
     resolution: {integrity: sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==}
 
@@ -1197,9 +1514,70 @@ packages:
       react:
         optional: true
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.5:
+    resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
 
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
@@ -1208,9 +1586,15 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   baseline-browser-mapping@2.8.9:
     resolution: {integrity: sha512-hY/u2lxLrbecMEWSB0IpGzGyDyeoMFQhCvZd2jGFSE5I17Fh01sYUBPCJtkWERw7zrac9+cIghxm/ytJa2X8iA==}
     hasBin: true
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   browserslist@4.26.2:
     resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
@@ -1221,8 +1605,20 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001745:
     resolution: {integrity: sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -1257,6 +1653,10 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1311,8 +1711,21 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.1:
     resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
@@ -1323,6 +1736,9 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.5.227:
     resolution: {integrity: sha512-ITxuoPfJu3lsNWUi2lBM2PaBPYgH3uqmxut5vmBxgYvyI4AlJ6P3Cai1O76mOrkJCBzq0IxWg/NtqOrpu/0gKA==}
@@ -1340,23 +1756,62 @@ packages:
   embla-carousel@8.5.1:
     resolution: {integrity: sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   fast-equals@5.3.2:
     resolution: {integrity: sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==}
     engines: {node: '>=6.0.0'}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   geist@1.3.1:
     resolution: {integrity: sha512-Q4gC1pBVPN+D579pBaz0TRRnGA4p9UK6elDY/xizXdFk/g4EKR5g0I+4p/Kj6gM0SajDBZ/0FvDV9ey9ud7BWw==}
@@ -1367,8 +1822,19 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   input-otp@1.4.1:
     resolution: {integrity: sha512-+yvpmKYKHi9jIGngxagY9oWiiblPB7+nEO75F2l2o4vs+6vpPZZmUl4tBNYuTCvQjhvEIbdNeJu70bhfYP2nbw==}
@@ -1383,12 +1849,41 @@ packages:
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.6.0:
     resolution: {integrity: sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==}
     hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
@@ -1461,6 +1956,12 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lucide-react@0.454.0:
     resolution: {integrity: sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==}
     peerDependencies:
@@ -1469,6 +1970,17 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1476,6 +1988,9 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1509,6 +2024,10 @@ packages:
       sass:
         optional: true
 
+  node-cron@4.2.1:
+    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
+    engines: {node: '>=6.0.0'}
+
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
@@ -1520,8 +2039,30 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -1532,6 +2073,10 @@ packages:
 
   postcss@8.5.0:
     resolution: {integrity: sha512-27VKOqrYfPncKA2NrFOVhP5MGAfHKLYn/Q0mz9cNQyRAKYi3VNHwYU2qKKqPCqgBmeeJ0uAFB56NumXZ5ZReXg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prop-types@15.8.1:
@@ -1622,6 +2167,11 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  rollup@4.52.3:
+    resolution: {integrity: sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
@@ -1637,6 +2187,21 @@ packages:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
@@ -1650,9 +2215,34 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1666,6 +2256,10 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tailwind-merge@2.5.5:
     resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
@@ -1686,8 +2280,34 @@ packages:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
 
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1743,6 +2363,97 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.7:
+    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -1759,13 +2470,106 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.28.4':
+    dependencies:
+      '@babel/types': 7.28.4
+
   '@babel/runtime@7.28.4': {}
+
+  '@babel/types@7.28.4':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@date-fns/tz@1.2.0': {}
 
   '@emnapi/runtime@1.5.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
     optional: true
 
   '@floating-ui/core@1.7.3':
@@ -1864,9 +2668,20 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
+
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1906,6 +2721,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@15.2.4':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@radix-ui/number@1.1.0': {}
@@ -2600,6 +3418,72 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
+  '@rollup/rollup-android-arm-eabi@4.52.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.3':
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -2678,6 +3562,10 @@ snapshots:
       postcss: 8.5.0
       tailwindcss: 4.1.9
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -2702,6 +3590,10 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@22.0.0':
     dependencies:
       undici-types: 6.11.1
@@ -2721,9 +3613,88 @@ snapshots:
       next: 15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.5
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.19
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.7(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.19
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   autoprefixer@10.4.20(postcss@8.5.0):
     dependencies:
@@ -2735,7 +3706,13 @@ snapshots:
       postcss: 8.5.0
       postcss-value-parser: 4.2.0
 
+  balanced-match@1.0.2: {}
+
   baseline-browser-mapping@2.8.9: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   browserslist@4.26.2:
     dependencies:
@@ -2749,7 +3726,19 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001745: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.1: {}
 
   chownr@3.0.0: {}
 
@@ -2776,10 +3765,8 @@ snapshots:
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-    optional: true
 
-  color-name@1.1.4:
-    optional: true
+  color-name@1.1.4: {}
 
   color-string@1.9.1:
     dependencies:
@@ -2792,6 +3779,12 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csstype@3.1.3: {}
 
@@ -2837,7 +3830,13 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
+
+  deep-eql@5.0.2: {}
 
   detect-libc@2.1.1: {}
 
@@ -2847,6 +3846,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
+
+  eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.227: {}
 
@@ -2862,18 +3863,71 @@ snapshots:
 
   embla-carousel@8.5.1: {}
 
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.3
 
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   eventemitter3@4.0.7: {}
 
+  expect-type@1.2.2: {}
+
   fast-equals@5.3.2: {}
 
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fraction.js@4.3.7: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   geist@1.3.1(next@15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
     dependencies:
@@ -2881,7 +3935,20 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
 
   input-otp@1.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -2893,9 +3960,42 @@ snapshots:
   is-arrayish@0.3.4:
     optional: true
 
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
@@ -2948,6 +4048,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
   lucide-react@0.454.0(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -2956,11 +4060,27 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minipass@7.1.2: {}
 
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
+
+  ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
@@ -2994,13 +4114,30 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-cron@4.2.1: {}
+
   node-releases@2.0.21: {}
 
   normalize-range@0.1.2: {}
 
   object-assign@4.1.1: {}
 
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -3011,6 +4148,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.0:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3110,10 +4253,37 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  rollup@4.52.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.3
+      '@rollup/rollup-android-arm64': 4.52.3
+      '@rollup/rollup-darwin-arm64': 4.52.3
+      '@rollup/rollup-darwin-x64': 4.52.3
+      '@rollup/rollup-freebsd-arm64': 4.52.3
+      '@rollup/rollup-freebsd-x64': 4.52.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.3
+      '@rollup/rollup-linux-arm64-gnu': 4.52.3
+      '@rollup/rollup-linux-arm64-musl': 4.52.3
+      '@rollup/rollup-linux-loong64-gnu': 4.52.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.3
+      '@rollup/rollup-linux-riscv64-musl': 4.52.3
+      '@rollup/rollup-linux-s390x-gnu': 4.52.3
+      '@rollup/rollup-linux-x64-gnu': 4.52.3
+      '@rollup/rollup-linux-x64-musl': 4.52.3
+      '@rollup/rollup-openharmony-arm64': 4.52.3
+      '@rollup/rollup-win32-arm64-msvc': 4.52.3
+      '@rollup/rollup-win32-ia32-msvc': 4.52.3
+      '@rollup/rollup-win32-x64-gnu': 4.52.3
+      '@rollup/rollup-win32-x64-msvc': 4.52.3
+      fsevents: 2.3.3
+
   scheduler@0.25.0: {}
 
-  semver@7.7.2:
-    optional: true
+  semver@7.7.2: {}
 
   server-only@0.0.1: {}
 
@@ -3144,6 +4314,16 @@ snapshots:
       '@img/sharp-win32-x64': 0.33.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
@@ -3156,12 +4336,44 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
+
   streamsearch@1.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   styled-jsx@5.1.6(react@19.0.0):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tailwind-merge@2.5.5: {}
 
@@ -3181,7 +4393,28 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
+
   tiny-invariant@1.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tslib@2.8.1: {}
 
@@ -3241,6 +4474,103 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  vite-node@3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.7(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.7(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.0.0
+      fsevents: 2.3.3
+      jiti: 2.6.0
+      lightningcss: 1.30.1
+
+  vitest@3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.7(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1)
+      vite-node: 3.2.4(@types/node@22.0.0)(jiti@2.6.0)(lightningcss@1.30.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.0.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
 
   yallist@5.0.0: {}
 

--- a/public/logistics-app.html
+++ b/public/logistics-app.html
@@ -2,127 +2,188 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Logistics Control Tower v2.5</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Vessel Control v3 – Integrated</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <style>
-    body{background:#0f172a;color:#e2e8f0;font-family:'Segoe UI',sans-serif}
-    .leaflet-container{background:#1f2937;border-radius:.75rem}
-    .leaflet-tooltip{background:rgba(15,23,42,.95);color:#fff;border:1px solid #475569;box-shadow:none;font-weight:600;padding:4px 8px}
-    .scrollbar-hide::-webkit-scrollbar{display:none}.scrollbar-hide{-ms-overflow-style:none;scrollbar-width:none}
-    .modal{transition:opacity .25s ease;z-index:10000}
-    body.modal-open{overflow:hidden}
-    #map{position:relative;z-index:0}
-    .leaflet-tooltip,.leaflet-popup{z-index:500!important}
-    .row-current{background:rgba(59,130,246,.15)}
-    .kbd{border:1px solid #475569;border-bottom-width:2px;border-radius:.375rem;padding:.15rem .35rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-    .tag{font-size:.75rem;padding:.1rem .4rem;border:1px solid #475569;border-radius:.5rem}
-    .chip{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;border-radius:.5rem;background:rgba(79,70,229,.2);color:#c7d2fe;font-size:.75rem}
-    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-    .btn { min-height: 44px; min-width: 44px; } /* 터치 타겟 44px 기준 */
+    :root {
+      --panel-height: 520px;
+      --schedule-max-height: 320px;
+    }
 
-    @media (prefers-contrast: more) {
-        :root {
-            --accent: #00b4ff;
-            --text: #ffffff;
-            --muted: #e2e8f0;
-        }
-        .panel, .status-card, .control-card { border-color: rgba(255,255,255,0.6); }
-        .pill { background: rgba(0,180,255,0.25); }
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+      color: #e2e8f0;
+      font-family: 'Segoe UI', sans-serif;
+    }
+
+    main {
+      flex: 1;
+      width: 100%;
+    }
+
+    .skeleton {
+      background-image: linear-gradient(90deg, rgba(255,255,255,0.06), rgba(255,255,255,0.14), rgba(255,255,255,0.06));
+      background-size: 200% 100%;
+      animation: shimmer 1.8s infinite;
+    }
+
+    @keyframes shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    .scrollbar-hide::-webkit-scrollbar { display: none; }
+    .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
+
+    .modal { transition: opacity .25s ease; z-index: 10000; }
+    .leaflet-container { background: transparent; border-radius: 0.75rem; }
+    .leaflet-tooltip { background: rgba(15,23,42,.95); color: #fff; border: 1px solid #475569; box-shadow: none; font-weight: 600; padding: 4px 8px; }
+
+    @media (min-width: 1280px) {
+      section[data-panel], aside[data-panel] {
+        min-height: var(--panel-height);
+      }
+      #schedule-container {
+        max-height: var(--schedule-max-height);
+      }
     }
   </style>
 </head>
-<body class="p-4">
-  <!-- Skip link for keyboard users -->
+<body class="bg-slate-950 text-slate-100" data-api-base-url="">
   <a href="#main" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;"
-     onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#0ea5e9';this.style.color='#000';this.style.borderRadius='8px';">
+     onfocus="this.style.position='static';this.style.width='auto';this.style.height='auto';this.style.padding='0.5rem 0.75rem';this.style.background='#38bdf8';this.style.color='#020617';this.style.borderRadius='0.5rem';">
      Skip to main content
   </a>
-  <main id="main" class="grid grid-cols-1 lg:grid-cols-5 gap-4 h-[95vh]" role="main" aria-live="polite">
-    <div id="map" class="lg:col-span-3 rounded-xl shadow-xl border border-slate-700 h-full min-h-[400px]" 
-         role="img" aria-label="Vessel tracking map showing route from MW4 to AGI" tabindex="0"></div>
 
-    <aside class="lg:col-span-2 flex flex-col gap-4 h-full" role="complementary" aria-label="Vessel control and schedule information">
-      <div id="info-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700">
-        <div class="flex items-center justify-between">
-          <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Vessel Control</h2>
-          <div class="flex items-center gap-2">
-            <span class="tag">Local: Asia/Dubai</span>
-            <div class="pill" id="marineBadge" title="Marine snapshot">Hs: -- m · Wind: -- kt</div>
-          </div>
-        </div>
-        <div id="vessel-info"><p class="text-slate-400">Loading vessel data...</p></div>
-
-        <div class="grid grid-cols-2 gap-2 mt-4">
-          <button id="briefing-btn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
-                  aria-describedby="briefing-desc">✨ Daily Briefing</button>
-          <button id="assistant-btn" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-3 rounded-lg transition-colors flex items-center justify-center gap-2 text-sm"
-                  aria-describedby="assistant-desc">🤖 Ask AI Assistant</button>
-        </div>
-        <div class="sr-only" id="briefing-desc">Generate AI-powered daily logistics briefing</div>
-        <div class="sr-only" id="assistant-desc">Open AI assistant chat for logistics questions</div>
-
-        <div class="mt-4 grid grid-cols-2 gap-2">
-          <label class="w-full">
-            <input type="file" id="file-schedule" class="hidden" accept=".csv,.json"/>
-            <span id="label-schedule" class="w-full inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Schedule (CSV/JSON)</span>
-          </label>
-          <label class="w-full">
-            <input type="file" id="file-weather" class="hidden" accept=".csv"/>
-            <span id="label-weather" class="w-full inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-3 rounded-lg cursor-pointer">Upload Weather (CSV)</span>
-          </label>
-        </div>
-        <p class="mt-3 text-xs text-slate-400">Tips: Press <span class="kbd">Esc</span> to close modals. 파일 포맷은 하단 가이드를 참고. API는 <span class="chip" id="api-status">API: Offline</span></p>
-      </div>
-
-      <div class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700 flex-grow flex flex-col h-1/2">
-        <div class="flex items-center justify-between border-b border-slate-600 pb-2 mb-3">
-          <h2 class="text-xl font-bold">Full Voyage Schedule</h2>
-          <span id="linkage-badge" class="tag" aria-live="polite">Linked to Weather: OFF</span>
-        </div>
-        <div id="schedule-container" class="overflow-y-auto scrollbar-hide flex-grow" aria-busy="false" role="region" aria-label="Voyage schedule table">
-          <table class="w-full text-left text-sm" role="table" aria-describedby="schedule-caption">
-            <caption id="schedule-caption" class="sr-only">Voyage schedule with ETD, ETA, cargo, and status information</caption>
-            <thead class="sticky top-0 bg-slate-900">
-              <tr role="row">
-                <th scope="col" id="th-voyage" role="columnheader">Voyage</th>
-                <th scope="col" id="th-cargo" role="columnheader">Cargo</th>
-                <th scope="col" id="th-etd" role="columnheader">ETD</th>
-                <th scope="col" id="th-eta" role="columnheader">ETA</th>
-                <th scope="col" id="th-status" role="columnheader">Status</th>
-                <th scope="col" id="th-ioi" role="columnheader">IOI (0–100)</th>
-                <th scope="col" id="th-decision" role="columnheader">Go/No-Go</th>
-              </tr>
-            </thead>
-            <tbody id="schedule-body" role="rowgroup"></tbody>
-          </table>
+  <header class="border-b border-slate-800/60 sticky top-0 z-40 bg-slate-950/80 backdrop-blur">
+    <div class="max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
+        <div id="header-vessel-name" class="text-lg font-semibold">🛳️ Loading…</div>
+        <div class="text-xs sm:text-sm text-slate-300">
+          IMO <span id="header-imo">—</span> · MMSI <span id="header-mmsi">—</span> · Local: <span id="header-timezone">Asia/Dubai</span>
         </div>
       </div>
-
-      <div id="risk-panel" class="bg-slate-900 p-4 rounded-xl shadow-lg border border-slate-700" role="region" aria-label="Risk simulation and control">
-        <div class="flex items-center justify-between">
-          <h2 class="text-xl font-bold border-b border-slate-600 pb-2 mb-3">Risk Simulation & Control</h2>
-          <button id="btn-ai-risk" class="text-xs bg-rose-600 hover:bg-rose-700 text-white px-3 py-1 rounded-md transition"
-                  aria-describedby="risk-scan-desc">AI Risk Scan</button>
-        </div>
-        <div class="flex items-center justify-between gap-3">
-          <p id="sim-time" class="text-lg font-mono" aria-live="polite" aria-label="Current simulation time"></p>
-          <div class="flex items-center gap-2">
-            <button id="btn-reset" class="bg-slate-700 hover:bg-slate-600 text-white text-sm px-3 py-2 rounded"
-                    aria-describedby="reset-desc">Reset Sim</button>
-            <span class="tag" id="sim-speed" aria-live="polite" aria-label="Simulation speed multiplier">×4.00</span>
-          </div>
-        </div>
-        <div id="alert-container" class="mt-4" role="alert" aria-live="polite" aria-atomic="false">
-          <p class="text-green-400">✅ 시스템 정상. 활성 위험 없음.</p>
-        </div>
-        <div class="sr-only" id="risk-scan-desc">Run AI-powered risk analysis on current voyage schedule</div>
-        <div class="sr-only" id="reset-desc">Reset simulation to initial state</div>
+      <div class="ml-auto flex items-center gap-2">
+        <span id="header-status" class="px-2 py-1 rounded-full text-xs bg-slate-800/80 text-slate-200">Loading…</span>
+        <button id="btn-quick-go" class="px-3 py-1.5 rounded-md bg-indigo-600/90 hover:bg-indigo-600 text-sm">✅ Quick Go</button>
+        <button id="btn-delay-24h" class="px-3 py-1.5 rounded-md bg-amber-600/90 hover:bg-amber-600 text-sm">⏸ Delay 24h</button>
+        <button id="btn-recalculate" class="px-3 py-1.5 rounded-md bg-slate-700 hover:bg-slate-600 text-sm">🔁 Recalculate</button>
       </div>
     </div>
-  </div>
+  </header>
+
+  <main id="main" class="max-w-7xl mx-auto w-full p-4 pb-24 grid grid-cols-1 xl:grid-cols-3 gap-4" role="main" aria-live="polite">
+    <section aria-label="Map" data-panel class="xl:col-span-1 bg-slate-900/60 rounded-2xl border border-slate-800 overflow-hidden flex flex-col">
+      <div class="p-3 flex items-center justify-between border-b border-slate-800">
+        <h2 class="font-semibold">Map &amp; Weather</h2>
+        <div class="flex gap-2 text-xs">
+          <span id="marine-badge" class="px-2 py-1 rounded bg-slate-800/80 text-sky-200">Hs: -- m · Wind: -- kt</span>
+        </div>
+      </div>
+      <div class="grow relative">
+        <div id="map" class="absolute inset-0 z-[1]"></div>
+        <div id="map-skeleton" class="absolute inset-0 skeleton"></div>
+        <div class="absolute bottom-3 left-3 text-xs bg-black/50 px-2 py-1 rounded z-[2]">Legend: 🌊 Swell · 💨 Wind</div>
+      </div>
+      <div class="p-3 grid grid-cols-3 gap-3 border-t border-slate-800 text-xs">
+        <div class="bg-slate-800/60 rounded-lg p-2">ETD: <b id="map-etd" class="text-slate-100">N/A</b></div>
+        <div class="bg-slate-800/60 rounded-lg p-2">ETA: <b id="map-eta" class="text-slate-100">N/A</b></div>
+        <div class="bg-slate-800/60 rounded-lg p-2">Risk: <span id="map-risk" class="text-amber-300">Calculating…</span></div>
+      </div>
+    </section>
+
+    <section aria-label="Schedule" data-panel class="xl:col-span-1 bg-slate-900/60 rounded-2xl border border-slate-800 overflow-hidden flex flex-col">
+      <div class="p-3 flex items-center justify-between border-b border-slate-800">
+        <h2 class="font-semibold">Full Voyage Schedule</h2>
+        <div class="text-xs text-slate-300">Linked to Weather: <span id="linkage-badge" class="text-rose-300">OFF</span></div>
+      </div>
+      <div id="schedule-container" class="overflow-auto flex-1">
+        <table class="w-full text-sm" role="table" aria-describedby="schedule-caption">
+          <caption id="schedule-caption" class="sr-only">Voyage schedule with ETD, ETA, IOI and risk decisions</caption>
+          <thead class="bg-slate-900/80 sticky top-0 z-10">
+            <tr class="text-left">
+              <th class="px-3 py-2">Voyage</th>
+              <th class="px-3 py-2">Cargo</th>
+              <th class="px-3 py-2">ETD</th>
+              <th class="px-3 py-2">ETA</th>
+              <th class="px-3 py-2">IOI</th>
+              <th class="px-3 py-2">Risk</th>
+              <th class="px-3 py-2">Go/No-Go</th>
+            </tr>
+          </thead>
+          <tbody id="schedule-body" class="divide-y divide-slate-800" role="rowgroup"></tbody>
+        </table>
+      </div>
+      <div class="p-3 flex flex-wrap items-center justify-between gap-3 border-t border-slate-800 text-xs">
+        <div class="text-slate-300">Tip: 행 클릭 → 항로 하이라이트 · 우측 패널 동기화</div>
+        <div class="flex items-center gap-2">
+          <label class="flex items-center gap-1"><input id="toggle-weather-link" type="checkbox" class="accent-indigo-500"> Weather Link</label>
+          <button id="btn-export" class="px-2 py-1 rounded bg-slate-800">Export CSV</button>
+        </div>
+      </div>
+    </section>
+
+    <aside aria-label="Controls" data-panel class="xl:col-span-1 bg-slate-900/60 rounded-2xl border border-slate-800 overflow-hidden flex flex-col">
+      <div class="p-3 border-b border-slate-800 flex items-center justify-between">
+        <h2 class="font-semibold">Control Center</h2>
+        <span id="api-status" class="text-xs text-rose-300">API: Checking…</span>
+      </div>
+      <div class="p-3 grid gap-3">
+        <div id="vessel-info" class="bg-slate-900/70 border border-slate-800 rounded-xl p-4 text-sm space-y-3">
+          <div class="skeleton h-4 rounded"></div>
+          <div class="skeleton h-4 rounded"></div>
+          <div class="skeleton h-20 rounded"></div>
+        </div>
+        <div id="ai-analysis-panel" class="hidden bg-slate-900/80 border border-slate-800 rounded-xl p-4 text-sm space-y-3" role="region" aria-label="AI weather analysis">
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold text-sky-300">✨ AI Weather Insight</h3>
+            <span class="text-xs px-2 py-1 rounded bg-slate-800">Screenshot Ready</span>
+          </div>
+          <div id="analysis-content" class="text-slate-200 bg-slate-950/80 rounded-lg p-3 text-sm leading-relaxed whitespace-pre-line"></div>
+        </div>
+        <button id="briefing-btn" class="w-full py-2 rounded-lg bg-fuchsia-700/80 hover:bg-fuchsia-700">✨ Daily Briefing</button>
+        <button id="assistant-btn" class="w-full py-2 rounded-lg bg-violet-700/80 hover:bg-violet-700">🤖 Ask AI Assistant</button>
+        <button id="btn-dispatch-report" class="w-full py-2 rounded-lg bg-sky-700/80 hover:bg-sky-600" aria-describedby="report-desc">📤 Send Daily Report</button>
+        <div class="grid grid-cols-2 gap-2">
+          <label class="flex">
+            <input type="file" id="file-schedule" class="hidden" accept=".csv,.json" />
+            <span id="label-schedule" class="w-full py-2 text-center rounded-lg bg-indigo-700/80 hover:bg-indigo-700 text-sm cursor-pointer">Upload Schedule (CSV/JSON)</span>
+          </label>
+          <label class="flex">
+            <input type="file" id="file-weather" class="hidden" accept=".csv,image/*" />
+            <span id="label-weather" class="w-full py-2 text-center rounded-lg bg-cyan-700/80 hover:bg-cyan-700 text-sm cursor-pointer">Upload Weather (CSV/Image)</span>
+          </label>
+        </div>
+        <div class="text-xs text-slate-300">파일 업로드 시 자동 파싱 → 스케줄/리스크 테이블에 반영</div>
+        <div class="sr-only" id="report-desc">Generate and dispatch the multi-channel daily report immediately</div>
+        <div id="assistant-hint" class="text-[11px] text-slate-400">Tips: Esc로 모달 닫기 · 붙여넣기(Ctrl/⌘+V)로 캡처 업로드</div>
+      </div>
+      <div class="mt-auto p-3 border-t border-slate-800 text-xs space-y-3">
+        <div class="flex items-center justify-between">
+          <div>Risk Scan</div>
+          <div class="flex items-center gap-2">
+            <button id="btn-ai-risk" class="px-2 py-1 rounded bg-slate-800">AI Scan</button>
+            <button id="btn-reset" class="px-2 py-1 rounded bg-slate-800">Reset Sim</button>
+            <span id="sim-speed" class="px-2 py-1 rounded bg-slate-800/70">×4.00</span>
+          </div>
+        </div>
+        <div id="sim-meta" class="text-slate-300">--:-- · 대기 · 초기화 중</div>
+        <div id="alert-container" class="bg-slate-900/70 border border-slate-800 rounded-lg p-3 text-xs text-emerald-300">✅ 시스템 초기화 중</div>
+      </div>
+    </aside>
+  </main>
+
+  <footer class="sticky bottom-0 z-40">
+    <div id="event-feed" class="max-w-7xl mx-auto m-4 rounded-xl bg-black/40 border border-slate-800 px-4 py-2 text-xs flex items-center gap-4 overflow-x-auto">
+      <span class="text-slate-300">🟢 Dashboard booting…</span>
+    </div>
+  </footer>
 
   <div id="briefing-modal" class="modal fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 opacity-0 pointer-events-none"
        role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-content" aria-hidden="true">
@@ -147,19 +208,20 @@
           </label>
         </div>
       </div>
-      <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto scrollbar-hide space-y-2 text-sm">
-        <div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
+      <div id="assistant-conversation" class="flex-grow bg-slate-950 p-4 rounded-md overflow-y-auto space-y-2 text-sm">
+        <div class="text-slate-400">무엇을 도와드릴까요? (예: "다음 3일 스케줄 요약")<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>
       </div>
-      <div class="mt-3 bg-slate-800/60 border border-slate-600 rounded-lg p-3">
+      <div id="assistant-dropzone" class="mt-3 bg-slate-800/60 border border-dashed border-slate-600 rounded-lg p-3">
         <div class="flex items-center justify-between">
           <div class="text-xs text-slate-300 font-semibold">Attachments</div>
           <button id="assistant-attach-btn" class="text-xs bg-slate-700 hover:bg-slate-600 text-white px-2 py-1 rounded">+ Add</button>
         </div>
+        <p class="mt-2 text-[11px] text-slate-400">+ 버튼을 누르거나 파일을 끌어다 놓고, 스크린 캡처는 붙여넣기(Ctrl/⌘+V)로 추가하세요.</p>
         <input type="file" id="assistant-file" class="hidden" accept="image/*,.pdf,.txt,.csv" multiple />
-        <div id="assistant-attachments" class="mt-2 text-xs text-slate-400 space-y-1"></div>
+        <div id="assistant-attachments" class="mt-3 text-xs text-slate-300 space-y-2 min-h-[3rem]" aria-live="polite"></div>
       </div>
       <form id="assistant-form" class="mt-3 flex gap-2" role="form" aria-label="AI Assistant Chat">
-        <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+        <input type="text" id="assistant-input" class="flex-grow bg-slate-800 text-white rounded-lg p-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-purple-500"
                placeholder="Ask a question..." aria-label="Type your question here" aria-describedby="assistant-input-desc">
         <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors"
                 aria-label="Send message">Send</button>
@@ -172,626 +234,1007 @@
       <button id="close-assistant-btn" class="mt-3 w-full bg-slate-700 hover:bg-slate-600 text-white font-bold py-2 px-4 rounded-lg transition-colors">Close</button>
     </div>
   </div>
-
   <script>
-    // requestIdleCallback 폴리필 (간단)
-    window.requestIdleCallback ||= (cb)=>setTimeout(()=>cb({didTimeout:false,timeRemaining:()=>0}), 1);
-    window.cancelIdleCallback ||= (id)=>clearTimeout(id);
+    window.requestIdleCallback ||= (cb) => setTimeout(() => cb({ didTimeout: false, timeRemaining: () => 0 }), 1);
+    window.cancelIdleCallback ||= (id) => clearTimeout(id);
 
     document.addEventListener('DOMContentLoaded', () => {
-      const API_BASE = window.APP_CONFIG?.apiBase ?? 'http://localhost:8000';
-      const tz = 'Asia/Dubai';
-      
-      // Scenario presets and port coordinates
-      const scenarioPresets = {
-        base:        { delayOnRisk: 4.0,  hs_caution: 1.50, hs_nogo: 2.50, wind_caution: 18, wind_nogo: 28 },
-        weather:     { delayOnRisk: 6.0,  hs_caution: 1.20, hs_nogo: 2.00, wind_caution: 16, wind_nogo: 24 },
-        congestion:  { delayOnRisk: 5.0,  hs_caution: 1.60, hs_nogo: 2.60, wind_caution: 20, wind_nogo: 30 },
-        inspection:  { delayOnRisk: 3.5, hs_caution: 1.80, hs_nogo: 2.80, wind_caution: 22, wind_nogo: 32 }
-      };
-      const RULE = scenarioPresets.base;
-      
-      const portCoords = {
-        'Shanghai':   { lat: 31.2304, lon: 121.4737 },
-        'Singapore':  { lat: 1.3521,  lon: 103.8198 },
-        'Colombo':    { lat: 6.9271,  lon: 79.8612  },
-        'Jebel Ali':  { lat: 25.006,  lon: 55.065   }
-      };
-      const fmtIso = (d)=> new Date(d).toISOString();
-      const toLocal = (d)=> new Date(d).toLocaleString('en-GB',{ timeZone: tz, dateStyle:'short', timeStyle:'medium' });
-      const pad2 = (n)=> String(n).padStart(2,'0');
-      const clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
-      const parseNum = (s)=> Number(String(s||'').trim());
-      const parseISO = (s)=> {
-        if(!s) return null;
-        const t = String(s).trim().replace(' ', 'T');
-        return isNaN(Date.parse(t)) ? null : new Date(t);
-      };
-      const parseCSV = (text)=>{
-        const lines = text.trim().split(/\r?\n/);
-        const header = lines.shift().split(',').map(h=>h.trim());
-        return lines.map(line=>{
-          const cells = line.split(',').map(c=>c.trim());
-          const obj={};
-          header.forEach((h,i)=> obj[h]=cells[i]);
-          return obj;
-        });
+      const API_BASE = document.body.dataset.apiBaseUrl || '';
+      const elements = {
+        header: {
+          vessel: document.getElementById('header-vessel-name'),
+          status: document.getElementById('header-status'),
+          timezone: document.getElementById('header-timezone'),
+          imo: document.getElementById('header-imo'),
+          mmsi: document.getElementById('header-mmsi'),
+        },
+        map: {
+          etd: document.getElementById('map-etd'),
+          eta: document.getElementById('map-eta'),
+          risk: document.getElementById('map-risk'),
+          skeleton: document.getElementById('map-skeleton'),
+          badge: document.getElementById('marine-badge'),
+        },
+        scheduleBody: document.getElementById('schedule-body'),
+        scheduleContainer: document.getElementById('schedule-container'),
+        linkageBadge: document.getElementById('linkage-badge'),
+        apiStatus: document.getElementById('api-status'),
+        vesselInfo: document.getElementById('vessel-info'),
+        simMeta: document.getElementById('sim-meta'),
+        simSpeed: document.getElementById('sim-speed'),
+        alert: document.getElementById('alert-container'),
+        eventFeed: document.getElementById('event-feed'),
+        analysisPanel: document.getElementById('ai-analysis-panel'),
+        analysisContent: document.getElementById('analysis-content'),
+        assistantConversation: document.getElementById('assistant-conversation'),
+        assistantUsage: document.getElementById('assistant-usage'),
+        assistantAttachments: document.getElementById('assistant-attachments'),
+        assistantDropzone: document.getElementById('assistant-dropzone'),
+        assistantModal: document.getElementById('assistant-modal'),
+        briefingModal: document.getElementById('briefing-modal'),
+        modalContent: document.getElementById('modal-content'),
       };
 
-      async function checkApiHealth(){
-        const badge = document.getElementById('api-status');
-        try{
-          const res = await fetch(`${API_BASE}/health`);
-          if(res.ok){
-            badge.textContent = 'API: Online';
-            badge.classList.remove('bg-rose-500/40');
-            badge.classList.add('bg-emerald-500/40','text-emerald-200');
-          }else{
-            throw new Error('Healthcheck failed');
+      const inputs = {
+        toggleWeather: document.getElementById('toggle-weather-link'),
+        fileSchedule: document.getElementById('file-schedule'),
+        fileWeather: document.getElementById('file-weather'),
+        assistantFile: document.getElementById('assistant-file'),
+        assistantInput: document.getElementById('assistant-input'),
+        assistantModel: document.getElementById('assistant-model'),
+      };
+
+      const labels = {
+        schedule: document.getElementById('label-schedule'),
+        weather: document.getElementById('label-weather'),
+      };
+
+      const buttons = {
+        quickGo: document.getElementById('btn-quick-go'),
+        delay: document.getElementById('btn-delay-24h'),
+        recalc: document.getElementById('btn-recalculate'),
+        export: document.getElementById('btn-export'),
+        briefing: document.getElementById('briefing-btn'),
+        assistantOpen: document.getElementById('assistant-btn'),
+        assistantAttach: document.getElementById('assistant-attach-btn'),
+        assistantReset: document.getElementById('assistant-reset'),
+        assistantClose: document.getElementById('close-assistant-btn'),
+        modalClose: document.getElementById('close-modal-btn'),
+        aiRisk: document.getElementById('btn-ai-risk'),
+        resetSim: document.getElementById('btn-reset'),
+        dispatchReport: document.getElementById('btn-dispatch-report'),
+      };
+
+      const state = {
+        timezone: 'Asia/Dubai',
+        vessel: null,
+        schedule: [],
+        weatherWindows: [],
+        ports: {},
+        events: [],
+        marine: null,
+        map: null,
+        marker: null,
+        polyline: null,
+        route: [],
+        simulation: {
+          now: new Date('2025-09-28T12:00:00Z'),
+          speedFactor: 240,
+          handle: null,
+        },
+        userInteractingWithSchedule: false,
+        interactionTimer: null,
+        lastAutoScrollVoyage: null,
+        weatherLinked: false,
+        pendingAttachments: [],
+        assistantHistory: [],
+        autoMarineHandle: null,
+        lastReport: null,
+      };
+
+      function clamp(value, min, max) { return Math.max(min, Math.min(max, value)); }
+      function feetToMeters(ft) { return ft / 3.28084; }
+      function metersToFeet(m) { return m * 3.28084; }
+      function parseISO(value) {
+        if (!value) return null;
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.valueOf()) ? null : parsed;
+      }
+      function toLocal(value) {
+        if (!value) return 'N/A';
+        return value.toLocaleString('ko-KR', { timeZone: state.timezone, dateStyle: 'medium', timeStyle: 'short' });
+      }
+      function applyReportStatus(status, report) {
+        state.lastReport = report || null;
+        let label = 'API: Offline';
+        let className = 'text-xs text-rose-300';
+        if (status === 'ok' || status === 'degraded') {
+          const okStatus = status === 'ok';
+          label = okStatus ? 'API: Online' : 'API: Degraded';
+          className = okStatus ? 'text-xs text-emerald-300' : 'text-xs text-amber-300';
+          if (report) {
+            const reportLabel = report.ok ? 'Report OK' : 'Report pending';
+            label += ` · ${reportLabel}`;
+            const tz = report.timezone || state.timezone;
+            const generated = parseISO(report.generatedAt);
+            if (generated) {
+              const local = generated.toLocaleString('ko-KR', { timeZone: tz, dateStyle: 'medium', timeStyle: 'short' });
+              elements.apiStatus.title = `Last report: ${local} (${tz})`;
+            } else {
+              elements.apiStatus.title = `Last report timezone: ${tz}`;
+            }
+          } else {
+            elements.apiStatus.title = 'Report: 아직 전송 기록 없음';
           }
-        }catch(err){
-          badge.textContent = 'API: Offline';
-          badge.classList.remove('bg-emerald-500/40','text-emerald-200');
-          badge.classList.add('bg-rose-500/40');
+        } else {
+          elements.apiStatus.title = 'Report status unavailable';
+        }
+        elements.apiStatus.textContent = label;
+        elements.apiStatus.className = className;
+      }
+      function safeNumber(value, fallback = null) {
+        const num = Number(value);
+        return Number.isFinite(num) ? num : fallback;
+      }
+
+      function updateCssHeights() {
+        const header = document.querySelector('header');
+        const footer = document.querySelector('footer');
+        const main = document.getElementById('main');
+        const viewport = window.innerHeight || document.documentElement.clientHeight || 0;
+        const headerHeight = header?.offsetHeight ?? 0;
+        const footerHeight = footer?.offsetHeight ?? 0;
+        let paddingTop = 0;
+        let paddingBottom = 0;
+        if (main) {
+          const styles = getComputedStyle(main);
+          paddingTop = Number.parseFloat(styles.paddingTop) || 0;
+          paddingBottom = Number.parseFloat(styles.paddingBottom) || 0;
+        }
+        const available = Math.max(440, viewport - headerHeight - footerHeight - paddingTop - paddingBottom - 24);
+        document.documentElement.style.setProperty('--panel-height', `${available}px`);
+        const scheduleHeader = document.querySelector('section[aria-label="Schedule"] .border-b');
+        const scheduleFooter = document.querySelector('section[aria-label="Schedule"] .border-t');
+        const scheduleTop = scheduleHeader?.offsetHeight ?? 0;
+        const scheduleBottom = scheduleFooter?.offsetHeight ?? 0;
+        const maxSchedule = Math.max(220, available - (scheduleTop + scheduleBottom + 48));
+        document.documentElement.style.setProperty('--schedule-max-height', `${maxSchedule}px`);
+      }
+
+      updateCssHeights();
+      window.addEventListener('resize', () => window.requestIdleCallback(updateCssHeights));
+
+      const haversine = (a, b) => {
+        const R = 6371e3;
+        const toRad = (d) => d * Math.PI / 180;
+        const [lat1, lon1] = a;
+        const [lat2, lon2] = b;
+        const dLat = toRad(lat2 - lat1);
+        const dLon = toRad(lon2 - lon1);
+        const phi1 = toRad(lat1);
+        const phi2 = toRad(lat2);
+        const h = Math.sin(dLat / 2) ** 2 + Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLon / 2) ** 2;
+        return 2 * R * Math.asin(Math.sqrt(h));
+      };
+
+      let routeSegments = [];
+      let totalMeters = 0;
+      function rebuildRouteSegments() {
+        routeSegments = [];
+        totalMeters = 0;
+        if (!Array.isArray(state.route) || state.route.length < 2) return;
+        for (let i = 0; i < state.route.length - 1; i += 1) {
+          const a = state.route[i];
+          const b = state.route[i + 1];
+          const m = haversine(a, b);
+          routeSegments.push({ a, b, m, start: totalMeters, end: totalMeters + m });
+          totalMeters += m;
         }
       }
 
-      checkApiHealth();
-
-      const map = L.map('map').setView([24.7, 54.1], 8);
-      L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {maxZoom:19, attribution:'&copy; OpenStreetMap & CARTO'}).addTo(map);
-
-      const vesselIcon = L.icon({iconUrl:'https://i.imgur.com/G4Am98f.png', iconSize:[35,35]});
-      const vesselData = {
-        name:"JOPETWIL 71", imo:"9582829", mmsi:"470486000",
-        route:[]
-      };
-      vesselData.route = [
-        [24.3400,54.4500], [24.4300,54.4300], [24.4700,54.3900],
-        [24.5600,54.2000], [24.6500,54.0000], [24.8500,53.8000],
-        [24.9500,53.7400], [24.9500,53.3000], [25.0200,53.0600],
-        [24.8400,53.6500]
-      ];
-      const vesselMarker = L.marker([24.34,54.45],{icon:vesselIcon})
-                .bindTooltip("JOPETWIL 71",{permanent:true,direction:'top',offset:[0,-18],className:'leaflet-tooltip'});
-      vesselMarker.addTo(map);
-      const vesselRoutePolyline = L.polyline(vesselData.route, {color:'#FBBF24', weight:3, dashArray:'5,10'}).addTo(map);
-      map.fitBounds(vesselRoutePolyline.getBounds(), {padding:[20,20]});
-
-      let currentSimDate = new Date("2025-09-28T12:00:00Z");
-      let speedFactor = 240;
-      let weatherLinked = false;
-      const simSpeedBadge = document.getElementById('sim-speed');
-      const linkageBadge = document.getElementById('linkage-badge');
-      simSpeedBadge.textContent = '×4.00';
-
-      let voyageSchedule = [
-        { id:"69th", cargo:"Dune Sand",  etd:"2025-09-28T16:00:00Z", eta:"2025-09-29T04:00:00Z", status:"Scheduled" },
-        { id:"70th", cargo:"10mm Agg.",  etd:"2025-09-30T16:00:00Z", eta:"2025-10-01T04:00:00Z", status:"Scheduled" },
-        { id:"71st", cargo:"5mm Agg.",   etd:"2025-10-02T16:00:00Z", eta:"2025-10-03T04:00:00Z", status:"Scheduled" }
-      ];
-
-      let weatherWindows = [];
-
-      const R=6371e3, toRad=d=>d*Math.PI/180;
-      function haversine(a,b){
-        const [lat1,lon1]=a,[lat2,lon2]=b;
-        const dLat=toRad(lat2-lat1), dLon=toRad(lon2-lon1);
-        const phi1=toRad(lat1), phi2=toRad(lat2);
-        const h=Math.sin(dLat/2)**2 + Math.cos(phi1)*Math.cos(phi2)*Math.sin(dLon/2)**2;
-        return 2*R*Math.asin(Math.sqrt(h));
-      }
-      const segments=[]; let totalMeters=0;
-      for(let i=0;i<vesselData.route.length-1;i++){
-        const a=vesselData.route[i], b=vesselData.route[i+1];
-        const m=haversine(a,b);
-        segments.push({a,b,m,accStart:totalMeters,accEnd:totalMeters+m});
-        totalMeters+=m;
-      }
-      function interpolateOnRoute(progress){
-        const target=clamp(progress,0,1)*totalMeters;
-        const seg=segments.find(s=>target>=s.accStart && target<=s.accEnd) || segments[segments.length-1];
-        const t=(target-seg.accStart)/(seg.m||1);
-        const lat=seg.a[0]+(seg.b[0]-seg.a[0])*t;
-        const lon=seg.a[1]+(seg.b[1]-seg.a[1])*t;
+      function interpolateRoute(progress) {
+        if (!routeSegments.length) return state.route[0] || [0, 0];
+        const target = clamp(progress, 0, 1) * totalMeters;
+        const seg = routeSegments.find((s) => target >= s.start && target <= s.end) || routeSegments[routeSegments.length - 1];
+        const factor = (target - seg.start) / (seg.m || 1);
+        const lat = seg.a[0] + (seg.b[0] - seg.a[0]) * factor;
+        const lon = seg.a[1] + (seg.b[1] - seg.a[1]) * factor;
         return [Number(lat.toFixed(5)), Number(lon.toFixed(5))];
       }
 
-      const infoPanel = document.getElementById('vessel-info');
-      const timeDisplay = document.getElementById('sim-time');
-      const scheduleContainer = document.getElementById('schedule-container');
-      const alertContainer = document.getElementById('alert-container');
-      const assistantConversation = document.getElementById('assistant-conversation');
-      const assistantUsage = document.getElementById('assistant-usage');
-      const assistantFileInput = document.getElementById('assistant-file');
-      const assistantAttachments = document.getElementById('assistant-attachments');
-      const assistantModelSelect = document.getElementById('assistant-model');
-      let assistantHistory = [];
-      let pendingAttachments = [];
-
-      function updateInfoPanel(){
-        const cur=vesselData.currentVoyageId||'N/A';
-        infoPanel.innerHTML =
-          `<h3 class="text-2xl font-bold text-cyan-400">${vesselData.name}</h3>
-           <p class="text-sm text-slate-400">IMO: ${vesselData.imo} / MMSI: ${vesselData.mmsi}</p>
-           <div class="mt-4 space-y-2">
-             <div><strong>Current Voyage:</strong> <span class="font-mono text-lg">${cur}</span></div>
-             <div><strong>Status:</strong> <span class="font-mono text-lg text-yellow-300">${vesselData.status}</span></div>
-           </div>`;
+      function logEvent(level, message) {
+        const emoji = level === 'error' ? '🔴' : level === 'warn' ? '🟡' : '🟢';
+        state.events.unshift({ timestamp: new Date().toISOString(), level, message: `${emoji} ${message}` });
+        state.events = state.events.slice(0, 12);
+        renderEventFeed();
       }
 
-      async function renderSchedule(){
-        const scheduleBody = document.getElementById('schedule-body');
-        if (!scheduleBody) return;
-        
-        document.getElementById('schedule-container').setAttribute('aria-busy','true');
-        scheduleBody.innerHTML = '';
-        
-        const marineDataCache = new Map();
-        
-        // Pre-fetch marine data once for all voyages
-        if (!marineDataCache.has('Jebel Ali')) {
-          const snap = await updateMarineForLeg('Jebel Ali');
-          marineDataCache.set('Jebel Ali', snap);
+      function renderEventFeed() {
+        elements.eventFeed.innerHTML = '';
+        state.events.forEach((evt) => {
+          const span = document.createElement('span');
+          span.className = evt.level === 'error' ? 'text-rose-300' : evt.level === 'warn' ? 'text-amber-300' : 'text-slate-300';
+          span.textContent = evt.message;
+          elements.eventFeed.appendChild(span);
+        });
+        if (!state.events.length) {
+          const span = document.createElement('span');
+          span.className = 'text-slate-400';
+          span.textContent = '대기 중 이벤트 없음';
+          elements.eventFeed.appendChild(span);
         }
-        const cachedSnap = marineDataCache.get('Jebel Ali');
-        
-        for (let index = 0; index < voyageSchedule.length; index += 1) {
-          const v = voyageSchedule[index];
-          let c="text-slate-300", pill="";
-          if(v.status==="In Transit") { c="text-blue-300"; pill='<span class="tag">Sailing</span>'; }
-          else if(v.status==="Delayed") { c="text-rose-300"; pill='<span class="tag">Delayed</span>'; }
-          else if(v.status==="Completed") { c="text-emerald-300"; pill='<span class="tag">Arrived</span>'; }
-          const hi=v.id===vesselData.currentVoyageId ? "row-current" : "";
-          
-          let ioi = 50; // Default IOI value
-          if (cachedSnap?.ioi) {
-            ioi = cachedSnap.ioi;
+      }
+
+      function guardedFetch(url, options) {
+        return fetch(url, options).then((res) => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`);
           }
-          
-          const decision = ioi >= 75 ? { tag: 'Go', tone: 'success' } : 
-                          ioi >= 55 ? { tag: 'Caution', tone: 'warn' } : 
-                          { tag: 'No-Go', tone: 'danger' };
-          
+          return res.json();
+        });
+      }
+
+      function setAlert(message, tone = 'info') {
+        const tones = {
+          info: 'text-slate-200 border-slate-700 bg-slate-900/70',
+          warn: 'text-amber-200 border-amber-500/40 bg-amber-900/30',
+          danger: 'text-rose-200 border-rose-500/40 bg-rose-900/30',
+        };
+        const chosen = tones[tone] || tones.info;
+        elements.alert.innerHTML = `<div class="rounded-lg border px-4 py-3 ${chosen}">${message}</div>`;
+      }
+
+      function updateVesselInfo() {
+        if (!state.vessel) {
+          elements.vesselInfo.innerHTML = '<div class="skeleton h-20 rounded"></div>';
+          return;
+        }
+        const currentVoyage = state.schedule.find((voyage) => voyage.id === state.vessel.currentVoyageId);
+        const etd = currentVoyage ? toLocal(parseISO(currentVoyage.etd)) : 'N/A';
+        const eta = currentVoyage ? toLocal(parseISO(currentVoyage.eta)) : 'N/A';
+        const progressPct = clamp((state.vessel.progress ?? 0) * 100, 0, 100);
+        elements.vesselInfo.innerHTML = `
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <h3 class="text-2xl font-bold text-cyan-400">${state.vessel.name}</h3>
+              <p class="text-sm text-slate-400">IMO: ${state.vessel.imo} / MMSI: ${state.vessel.mmsi}</p>
+            </div>
+            <span class="px-2 py-1 rounded-md text-xs bg-slate-800/80 border border-slate-600">${state.timezone}</span>
+          </div>
+          <div class="grid grid-cols-2 gap-3 text-sm">
+            <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+              <p class="text-slate-400 text-xs uppercase tracking-wider">Current Voyage</p>
+              <p class="mt-1 font-mono text-lg text-emerald-300">${state.vessel.currentVoyageId ?? 'N/A'}</p>
+            </div>
+            <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+              <p class="text-slate-400 text-xs uppercase tracking-wider">Status</p>
+              <p class="mt-1 font-semibold text-sky-300">${state.vessel.status}</p>
+            </div>
+          </div>
+          <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-3">
+            <div class="flex items-center justify-between text-xs text-slate-400">
+              <span>Leg Progress</span>
+              <span class="font-mono text-slate-200">${progressPct.toFixed(2)}%</span>
+            </div>
+            <div class="w-full h-2 bg-slate-900/80 rounded-full mt-2">
+              <div class="h-2 rounded-full bg-gradient-to-r from-cyan-400 via-sky-500 to-emerald-400" style="width:${progressPct.toFixed(2)}%"></div>
+            </div>
+            <div class="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-400">
+              <div>
+                <span class="block uppercase tracking-wide">ETD</span>
+                <span class="font-mono text-slate-200">${etd}</span>
+              </div>
+              <div>
+                <span class="block uppercase tracking-wide">ETA</span>
+                <span class="font-mono text-slate-200">${eta}</span>
+              </div>
+            </div>
+          </div>`;
+      }
+      function renderSchedule() {
+        if (!elements.scheduleBody) return;
+        elements.scheduleBody.innerHTML = '';
+        const safeMarineHs = state.marine?.hs ?? null;
+        const safeMarineWind = state.marine?.windKt ?? null;
+        const safeMarineIoi = state.marine?.ioi ?? null;
+
+        const riskSummary = (voyage) => {
+          const hs = safeMarineHs ?? feetToMeters(voyage.swellFt);
+          const wind = safeMarineWind ?? voyage.windKt;
+          return `🌊 ${metersToFeet(hs).toFixed(2)} ft · 💨 ${wind.toFixed(2)} kt`;
+        };
+
+        state.schedule.forEach((voyage) => {
           const row = document.createElement('tr');
-          row.id = `voyage-${v.id}`;
-          row.className = `border-t border-slate-700 ${hi}`;
-          row.setAttribute('role', 'row');
+          row.className = `hover:bg-slate-800/40 ${voyage.id === state.vessel?.currentVoyageId ? 'bg-slate-800/50' : ''}`;
+          row.setAttribute('tabindex', '0');
+          const ioi = safeNumber(voyage.ioi, safeMarineIoi ?? 50);
+          const decision = ioi >= 75 ? { label: 'GO', classes: 'bg-emerald-900/40 text-emerald-300' } : ioi >= 55 ? { label: 'WATCH', classes: 'bg-amber-900/40 text-amber-300' } : { label: 'NO-GO', classes: 'bg-rose-900/40 text-rose-300' };
+          const barClass = decision.label === 'GO' ? 'bg-emerald-500' : decision.label === 'WATCH' ? 'bg-amber-500' : 'bg-rose-500';
           row.innerHTML = `
-            <td class="p-2 font-bold" role="gridcell" aria-describedby="th-voyage">${v.id}</td>
-            <td class="p-2" role="gridcell" aria-describedby="th-cargo">${v.cargo}</td>
-            <td class="p-2" role="gridcell" aria-describedby="th-etd">${toLocal(v.etd)}</td>
-            <td class="p-2" role="gridcell" aria-describedby="th-eta">${toLocal(v.eta)}</td>
-            <td class="p-2 ${c} font-semibold" role="gridcell" aria-describedby="th-status">${v.status} ${pill}</td>
-            <td class="p-2" role="gridcell" aria-describedby="th-ioi">${ioi}</td>
-            <td class="p-2" role="gridcell" aria-describedby="th-decision"><span class="pill ${decision.tone === 'danger' ? 'danger' : ''}">${decision.tag}</span></td>
-          `;
-          scheduleBody.appendChild(row);
-        }
-        
-        document.getElementById('schedule-container').setAttribute('aria-busy','false');
+            <td class="px-3 py-2 font-medium">${voyage.id}</td>
+            <td class="px-3 py-2">${voyage.cargo}</td>
+            <td class="px-3 py-2">${toLocal(parseISO(voyage.etd))}</td>
+            <td class="px-3 py-2">${toLocal(parseISO(voyage.eta))}</td>
+            <td class="px-3 py-2">
+              <div class="w-24 h-2 bg-slate-800 rounded-full overflow-hidden">
+                <div class="h-2 ${barClass}" style="width:${clamp(ioi, 0, 100).toFixed(2)}%"></div>
+              </div>
+            </td>
+            <td class="px-3 py-2 text-xs">${riskSummary(voyage)}</td>
+            <td class="px-3 py-2"><span class="px-2 py-1 rounded-md text-xs ${decision.classes}">${decision.label}</span></td>`;
 
-        if(vesselData.currentVoyageId){
-          const row=document.getElementById(`voyage-${vesselData.currentVoyageId}`);
-          if(row) row.scrollIntoView({block:'center',behavior:'smooth'});
-        }
-      }
+          row.addEventListener('click', () => {
+            state.vessel.currentVoyageId = voyage.id;
+            state.vessel.progress = 0;
+            state.vessel.status = voyage.status;
+            updateVesselInfo();
+            renderSchedule();
+            focusVoyageOnMap(voyage);
+            logEvent('info', `${voyage.id} 선택됨 · 맵 하이라이트`);
+          });
 
-      function setInfo(msgHtml, tone='info'){
-        const color = tone==='warn' ? 'bg-yellow-900 border-yellow-500 text-yellow-100'
-                     : tone==='danger' ? 'bg-rose-900 border-rose-500 text-rose-100'
-                     : 'bg-slate-950 border-slate-600 text-slate-200';
-        alertContainer.innerHTML = `<div class="${color} px-4 py-3 rounded border">${msgHtml}</div>`;
-      }
+          row.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              row.click();
+            }
+          });
 
-      const LIM = {
-        waveWarnM: 1.75, waveNoGoM: 2.25,
-        windWarnKt: 24, windNoGoKt: 30,
-        visNoGoKm: 1.0
-      };
+          elements.scheduleBody.appendChild(row);
+        });
 
-      function buildWeatherWindows(rows){
-        weatherWindows = rows.map(r=>{
-          const start = parseISO(r.start);
-          const end   = parseISO(r.end);
-          const wv = parseNum(r.wave_m);
-          const wd = parseNum(r.wind_kt);
-          const vs = parseNum(r.vis_km);
-          let level = 'None';
-          if(isFinite(wv) && isFinite(wd) && isFinite(vs)){
-            if(wv >= LIM.waveNoGoM || wd >= LIM.windNoGoKt || vs <= LIM.visNoGoKm) level='NoGo';
-            else if(wv >= LIM.waveWarnM || wd >= LIM.windWarnKt) level='Warn';
-          }
-          return { start, end, level, waveM:wv, windKt:wd, visKm:vs };
-        }).filter(w => w.start && w.end);
-      }
-
-      function findWeatherLevelAt(dt){
-        const t = +dt;
-        const w = weatherWindows.find(win => t>= +win.start && t<= +win.end);
-        return w ? w.level : 'None';
-      }
-
-      function relHours(a,b){ return ( (+a)-(+b) )/36e5; }
-
-      function applyWeatherToSchedule(){
-        if(weatherWindows.length===0){ linkageBadge.textContent='Linked to Weather: OFF'; return; }
-        linkageBadge.textContent='Linked to Weather: ON';
-
-        voyageSchedule.sort((x,y)=> +new Date(x.etd) - +new Date(y.etd));
-
-        let lastETA = null;
-        let changes = [];
-
-        for(let i=0;i<voyageSchedule.length;i++){
-          const v = voyageSchedule[i];
-          let etd = new Date(v.etd);
-          let eta = new Date(v.eta);
-          if(lastETA && +etd < +lastETA){
-            const deltaH = Math.ceil(relHours(lastETA, etd));
-            etd = new Date(+etd + deltaH*36e5);
-            eta = new Date(+eta + deltaH*36e5);
-            changes.push(`${v.id}: shifted +${deltaH}h to keep sequence`);
-          }
-
-          const lvlAtETD = findWeatherLevelAt(etd);
-          const lvlAtETA = findWeatherLevelAt(eta);
-
-          if(lvlAtETD==='NoGo'){
-            etd = new Date(+etd + 24*36e5);
-            eta = new Date(+eta + 24*36e5);
-            v.status = 'Delayed';
-            changes.push(`${v.id}: ETD NoGo → +24h`);
-          }else if(lvlAtETA==='NoGo'){
-            eta = new Date(+eta + 12*36e5);
-            v.status = 'Delayed';
-            changes.push(`${v.id}: ETA NoGo → +12h`);
-          }
-
-          v.etd = fmtIso(etd);
-          v.eta = fmtIso(eta);
-          lastETA = eta;
-        }
-
-        if(changes.length){
-          setInfo(`<strong>Weather linked.</strong><br>${changes.map(c=>`• ${c}`).join('<br>')}`, 'warn');
-        }else{
-          setInfo('날씨 연동됨. 변경 사항 없음.');
-        }
-        renderSchedule();
-      }
-
-      function chooseActiveVoyage(now){
-        return voyageSchedule.find(v => v.status==="In Transit" || ((new Date(v.etd)<=now) && (v.status==="Scheduled" || v.status==="Delayed")));
-      }
-
-      function runSimulation(){
-        currentSimDate.setMinutes(currentSimDate.getMinutes() + (1 * speedFactor / 60));
-        timeDisplay.textContent = toLocal(currentSimDate);
-
-        let active = chooseActiveVoyage(currentSimDate);
-        if(active && vesselData.currentVoyageId!==active.id){
-          vesselData.currentVoyageId=active.id; vesselData.progress=0.00;
-        }
-
-        if(active){
-          const etd=new Date(active.etd), eta=new Date(active.eta);
-          const total=eta-etd;
-          if(currentSimDate>=etd && currentSimDate<=eta){
-            if(active.status!=="Delayed") active.status="In Transit";
-            vesselData.status = active.status==="Delayed" ? "In Transit (Delayed)" : "In Transit to AGI";
-            vesselData.progress=(currentSimDate-etd)/total;
-            const [lat,lon]=interpolateOnRoute(vesselData.progress);
-            vesselMarker.setLatLng([lat,lon]);
-          }else if(currentSimDate>eta){
-            if(active.status!=="Completed"){
-              active.status="Completed";
-              vesselMarker.setLatLng(vesselData.route[vesselData.route.length-1]);
-              vesselData.status="Discharging @ AGI";
-              setTimeout(()=>{
-                vesselMarker.setLatLng(vesselData.route[0]);
-                vesselData.status="Ready for Loading @ MW4";
-                updateInfoPanel();
-              }, 4000);
+        if (state.vessel?.currentVoyageId) {
+          const index = state.schedule.findIndex((voyage) => voyage.id === state.vessel.currentVoyageId);
+          if (index >= 0) {
+            const selected = elements.scheduleBody.children[index];
+            const changed = state.vessel.currentVoyageId !== state.lastAutoScrollVoyage;
+            if (selected && (changed || !state.userInteractingWithSchedule)) {
+              selected.scrollIntoView({ behavior: state.lastAutoScrollVoyage ? 'smooth' : 'auto', block: 'center' });
+              state.lastAutoScrollVoyage = state.vessel.currentVoyageId;
             }
           }
         }
+      }
 
-        updateInfoPanel();
+      function focusVoyageOnMap(voyage) {
+        if (!state.map || !voyage) return;
+        const etd = parseISO(voyage.etd);
+        const eta = parseISO(voyage.eta);
+        elements.map.etd.textContent = toLocal(etd);
+        elements.map.eta.textContent = toLocal(eta);
+        if (state.marker) {
+          const el = state.marker.getElement();
+          if (el) {
+            el.classList.add('ring-2', 'ring-emerald-400');
+            setTimeout(() => el.classList.remove('ring-2', 'ring-emerald-400'), 1200);
+          }
+        }
+      }
+
+      function updateMap() {
+        if (!state.map) {
+          state.map = L.map('map').setView([24.7, 54.1], 8);
+          L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { maxZoom: 19, attribution: '&copy; OpenStreetMap & CARTO' }).addTo(state.map);
+        }
+        if (elements.map.skeleton) {
+          elements.map.skeleton.classList.add('hidden');
+        }
+        if (state.polyline) {
+          state.map.removeLayer(state.polyline);
+        }
+        state.polyline = L.polyline(state.route, { color: '#FBBF24', weight: 3, dashArray: '5,10' }).addTo(state.map);
+        if (!state.marker) {
+          const vesselIcon = L.icon({ iconUrl: 'https://i.imgur.com/G4Am98f.png', iconSize: [35, 35] });
+          state.marker = L.marker(state.route[0], { icon: vesselIcon })
+            .bindTooltip(state.vessel?.name || 'Vessel', { permanent: true, direction: 'top', offset: [0, -18], className: 'leaflet-tooltip' })
+            .addTo(state.map);
+        }
+        state.marker.setLatLng(state.route[0]);
+        state.map.fitBounds(state.polyline.getBounds(), { padding: [20, 20] });
+        rebuildRouteSegments();
+      }
+
+      function populateFromDataset(dataset) {
+        state.timezone = dataset.timezone;
+        state.vessel = {
+          ...dataset.vessel,
+          currentVoyageId: dataset.schedule[0]?.id ?? null,
+          progress: 0,
+        };
+        state.schedule = dataset.schedule;
+        state.weatherWindows = dataset.weatherWindows;
+        state.ports = dataset.ports;
+        state.route = dataset.route;
+        state.events = dataset.events.map((evt) => ({ level: evt.level, message: evt.message, timestamp: evt.timestamp }));
+        elements.header.vessel.textContent = `🛳️ ${state.vessel.name}`;
+        elements.header.status.textContent = state.vessel.status;
+        elements.header.status.className = 'px-2 py-1 rounded-full text-xs bg-emerald-900/40 text-emerald-300';
+        elements.header.timezone.textContent = state.timezone;
+        elements.header.imo.textContent = state.vessel.imo;
+        elements.header.mmsi.textContent = state.vessel.mmsi;
+        state.simulation.now = parseISO(dataset.serverTime) || new Date();
+        renderEventFeed();
+        updateVesselInfo();
+        renderSchedule();
+        updateMap();
+      }
+
+      function checkApiHealth() {
+        guardedFetch(`${API_BASE}/api/health`).then((data) => {
+          const report = data?.report || null;
+          const previousId = state.lastReport?.generatedAt;
+          applyReportStatus(data?.status || 'ok', report);
+          if (report && !report.ok && report.generatedAt !== previousId) {
+            logEvent('warn', '최근 보고 전송에서 일부 채널 실패 감지');
+          }
+        }).catch((error) => {
+          console.error(error);
+          applyReportStatus('offline');
+        });
+      }
+
+      function refreshMarineSnapshot(showToast = false) {
+        const port = state.vessel?.port || 'Jebel Ali';
+        return guardedFetch(`${API_BASE}/api/marine?port=${encodeURIComponent(port)}`).then((snapshot) => {
+          state.marine = snapshot;
+          if (snapshot.hs !== null && snapshot.windKt !== null) {
+            elements.map.badge.textContent = `Hs: ${snapshot.hs.toFixed(2)} m · Wind: ${snapshot.windKt.toFixed(2)} kt`;
+          } else {
+            elements.map.badge.textContent = 'Hs: -- m · Wind: -- kt';
+          }
+          if (snapshot.ioi !== null && snapshot.hs !== null) {
+            elements.map.risk.textContent = `${snapshot.ioi.toFixed(0)} IOI · Hs ${snapshot.hs.toFixed(2)} m`;
+          } else if (snapshot.ioi !== null) {
+            elements.map.risk.textContent = `${snapshot.ioi.toFixed(0)} IOI`;
+          } else {
+            elements.map.risk.textContent = '데이터 수집 중';
+          }
+          renderSchedule();
+          if (showToast) {
+            logEvent('info', `해상 스냅샷 업데이트 (${snapshot.cached ? 'cache' : 'live'})`);
+          }
+        }).catch((error) => {
+          console.error(error);
+          logEvent('warn', '해상 스냅샷 업데이트 실패 – 기존 값 사용');
+        });
+      }
+
+      function startMarineAutoRefresh() {
+        if (state.autoMarineHandle) {
+          clearInterval(state.autoMarineHandle);
+        }
+        state.autoMarineHandle = setInterval(() => refreshMarineSnapshot(true), 5 * 60 * 1000);
+      }
+
+      function chooseActiveVoyage(now) {
+        const date = now.valueOf();
+        return state.schedule.find((voyage) => {
+          const etd = parseISO(voyage.etd);
+          const eta = parseISO(voyage.eta);
+          if (!etd || !eta) return false;
+          return (date >= etd.valueOf() && date <= eta.valueOf()) || voyage.status === 'In Transit';
+        }) || state.schedule[0];
+      }
+
+      function runSimulationTick() {
+        const sim = state.simulation;
+        sim.now = new Date(sim.now.valueOf() + sim.speedFactor * 1000);
+        elements.simMeta.textContent = `${toLocal(sim.now)} · ${state.vessel.status}`;
+        const active = chooseActiveVoyage(sim.now);
+        if (active) {
+          if (state.vessel.currentVoyageId !== active.id) {
+            state.vessel.currentVoyageId = active.id;
+            state.vessel.progress = 0;
+            renderSchedule();
+          }
+          const etd = parseISO(active.etd);
+          const eta = parseISO(active.eta);
+          if (etd && eta) {
+            if (sim.now >= etd && sim.now <= eta) {
+              state.vessel.status = active.status === 'Delayed' ? 'In Transit (Delayed)' : 'In Transit to AGI';
+              const total = eta.valueOf() - etd.valueOf();
+              state.vessel.progress = clamp((sim.now.valueOf() - etd.valueOf()) / total, 0, 1);
+              if (state.marker) {
+                const [lat, lon] = interpolateRoute(state.vessel.progress);
+                state.marker.setLatLng([lat, lon]);
+              }
+            } else if (sim.now > eta && active.status !== 'Completed') {
+              active.status = 'Completed';
+              state.vessel.status = 'Discharging @ AGI';
+              logEvent('info', `${active.id} 도착 – 하역 진행 중`);
+              setTimeout(() => {
+                state.vessel.status = state.vessel.readiness;
+                updateVesselInfo();
+                renderSchedule();
+              }, 5000);
+            }
+          }
+        }
+        updateVesselInfo();
+      }
+
+      function startSimulationLoop() {
+        if (state.simulation.handle) return;
+        state.simulation.handle = setInterval(runSimulationTick, 1000);
+      }
+
+      function stopSimulationLoop() {
+        if (!state.simulation.handle) return;
+        clearInterval(state.simulation.handle);
+        state.simulation.handle = null;
+      }
+
+      function resetSimulation() {
+        stopSimulationLoop();
+        state.simulation.now = new Date('2025-09-28T12:00:00Z');
+        state.vessel.currentVoyageId = state.schedule[0]?.id ?? null;
+        state.vessel.status = state.vessel.readiness;
+        state.vessel.progress = 0;
+        state.weatherLinked = false;
+        elements.linkageBadge.textContent = 'OFF';
+        inputs.toggleWeather.checked = false;
+        state.schedule = state.schedule.map((voyage) => ({ ...voyage, status: 'Scheduled' }));
+        renderSchedule();
+        updateVesselInfo();
+        setAlert('시뮬레이터 시계가 초기화되었습니다.');
+        logEvent('info', '시뮬레이터 초기화 완료');
+        startSimulationLoop();
+      }
+      function applyWeatherWindows() {
+        if (!state.weatherLinked || !state.weatherWindows.length) {
+          elements.linkageBadge.textContent = 'OFF';
+          return;
+        }
+        elements.linkageBadge.textContent = 'ON';
+        const windows = state.weatherWindows.map((window) => ({
+          ...window,
+          start: parseISO(window.start),
+          end: parseISO(window.end),
+        }));
+        const updates = [];
+        let lastEta = null;
+        state.schedule = state.schedule.map((voyage) => {
+          const etd = parseISO(voyage.etd);
+          const eta = parseISO(voyage.eta);
+          if (!etd || !eta) return voyage;
+          let newEtd = new Date(etd);
+          let newEta = new Date(eta);
+          if (lastEta && newEtd < lastEta) {
+            const shiftHours = Math.ceil((lastEta.valueOf() - newEtd.valueOf()) / 36e5);
+            newEtd = new Date(newEtd.valueOf() + shiftHours * 36e5);
+            newEta = new Date(newEta.valueOf() + shiftHours * 36e5);
+            updates.push(`${voyage.id}: sequence shift +${shiftHours}h`);
+          }
+          const conflict = windows.find((win) => win.start && win.end && ((newEtd >= win.start && newEtd <= win.end) || (newEta >= win.start && newEta <= win.end)));
+          if (conflict && (conflict.wave_m >= 2.25 || conflict.wind_kt >= 30 || conflict.vis_km <= 1)) {
+            newEtd = new Date(newEtd.valueOf() + 24 * 36e5);
+            newEta = new Date(newEta.valueOf() + 24 * 36e5);
+            voyage.status = 'Delayed';
+            updates.push(`${voyage.id}: Severe weather window detected → +24h`);
+          }
+          lastEta = newEta;
+          return { ...voyage, etd: newEtd.toISOString(), eta: newEta.toISOString() };
+        });
+        if (updates.length) {
+          setAlert(`<strong>Weather linked.</strong><br>${updates.map((line) => `• ${line}`).join('<br>')}`, 'warn');
+        } else {
+          setAlert('날씨 연동 완료. 변경 사항 없음.');
+        }
         renderSchedule();
       }
 
-      const scheduleInput = document.getElementById('file-schedule');
-      const weatherInput  = document.getElementById('file-weather');
-      const scheduleLabel = document.getElementById('label-schedule');
-      const weatherLabel  = document.getElementById('label-weather');
+      function parseCSV(text) {
+        const rows = text.trim().split(/\r?\n/);
+        const header = rows.shift().split(',').map((cell) => cell.trim());
+        return rows.map((line) => {
+          const cells = line.split(',').map((cell) => cell.trim());
+          const obj = {};
+          header.forEach((key, index) => {
+            obj[key] = cells[index];
+          });
+          return obj;
+        });
+      }
 
-      scheduleLabel.addEventListener('click',()=> scheduleInput.click());
-      weatherLabel.addEventListener('click',()=> weatherInput.click());
+      function addScheduleListeners() {
+        const passive = { passive: true };
+        const markInteraction = () => {
+          state.userInteractingWithSchedule = true;
+          if (state.interactionTimer) clearTimeout(state.interactionTimer);
+          state.interactionTimer = setTimeout(() => {
+            state.userInteractingWithSchedule = false;
+          }, 8000);
+        };
+        ['wheel', 'touchstart', 'touchmove', 'pointerdown', 'keydown', 'scroll'].forEach((evt) => {
+          elements.scheduleContainer.addEventListener(evt, markInteraction, passive);
+        });
+      }
 
-      scheduleInput.addEventListener('change', (e)=> {
-        if(e.target.files.length===0) return;
-        const f = e.target.files[0];
+      addScheduleListeners();
+
+      function openModal(modal) {
+        modal.classList.remove('opacity-0', 'pointer-events-none');
+        modal.setAttribute('aria-hidden', 'false');
+        const focusable = modal.querySelectorAll('button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length) {
+          focusable[0].focus();
+        }
+      }
+
+      function closeModal(modal) {
+        modal.classList.add('opacity-0', 'pointer-events-none');
+        modal.setAttribute('aria-hidden', 'true');
+      }
+
+      [elements.assistantModal, elements.briefingModal].forEach((modal) => {
+        modal.addEventListener('click', (event) => {
+          if (event.target === modal) closeModal(modal);
+        });
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeModal(elements.assistantModal);
+          closeModal(elements.briefingModal);
+        }
+      });
+
+      function renderAttachments() {
+        if (!state.pendingAttachments.length) {
+          elements.assistantAttachments.innerHTML = '<div class="text-slate-500 text-[11px]">첨부된 파일이 없습니다. 스크린 캡처 붙여넣기를 지원합니다.</div>';
+          return;
+        }
+        elements.assistantAttachments.innerHTML = state.pendingAttachments.map((file, index) => {
+          const isImage = (file.type || '').startsWith('image/');
+          const preview = isImage ? `<img src="${URL.createObjectURL(file)}" alt="${file.name} preview" class="w-12 h-12 object-cover rounded-md border border-slate-700" onload="URL.revokeObjectURL(this.src)">`
+            : '<span class="w-12 h-12 flex items-center justify-center rounded-md bg-slate-900/70 border border-slate-700 text-lg">📄</span>';
+          const sizeKb = file.size ? (file.size / 1024).toFixed(2) : '0.00';
+          return `<div class="flex items-center gap-3 bg-slate-900/70 px-3 py-2 rounded-lg border border-slate-800/70">
+              ${preview}
+              <div class="flex-1 min-w-0">
+                <p class="text-slate-200 text-sm truncate">${file.name}</p>
+                <p class="text-slate-500 text-[11px]">${file.type || 'unknown'} • ${sizeKb} KB</p>
+              </div>
+              <button data-index="${index}" class="text-rose-300 hover:text-rose-200 text-xs remove-attachment">Remove</button>
+            </div>`;
+        }).join('');
+        elements.assistantAttachments.querySelectorAll('.remove-attachment').forEach((button) => {
+          button.addEventListener('click', (event) => {
+            const idx = Number(event.currentTarget.getAttribute('data-index'));
+            state.pendingAttachments.splice(idx, 1);
+            renderAttachments();
+          });
+        });
+      }
+
+      function addAttachmentsFromFileList(list) {
+        const files = Array.from(list || []);
+        if (!files.length) return;
+        state.pendingAttachments = state.pendingAttachments.concat(files);
+        renderAttachments();
+      }
+
+      renderAttachments();
+      function callAssistant(prompt, options = {}) {
+        const attachments = options.attachments ?? state.pendingAttachments;
+        const persistHistory = options.persist ?? true;
+        const formData = new FormData();
+        formData.append('prompt', prompt);
+        formData.append('history', JSON.stringify(state.assistantHistory));
+        formData.append('model', inputs.assistantModel.value);
+        attachments.forEach((file) => formData.append('files', file, file.name || 'attachment'));
+        return fetch(`${API_BASE}/api/assistant`, { method: 'POST', body: formData }).then((res) => {
+          if (!res.ok) throw new Error('Assistant call failed');
+          return res.json();
+        }).then((data) => {
+          if (persistHistory) {
+            state.assistantHistory.push({ role: 'user', content: prompt });
+            state.assistantHistory.push({ role: 'assistant', content: data.answer });
+          }
+          if (!options.attachments) {
+            state.pendingAttachments = [];
+            renderAttachments();
+            inputs.assistantFile.value = '';
+          }
+          elements.assistantUsage.textContent = `Last response model: ${inputs.assistantModel.value}`;
+          return data.answer;
+        });
+      }
+
+      function runRiskScan() {
+        setAlert('AI 위험 스캔 실행 중...', 'info');
+        return callAssistant('risk summary for upcoming voyages', { persist: false }).then((answer) => {
+          setAlert(answer.replace(/\n/g, '<br>'), 'warn');
+        }).catch((error) => {
+          console.error(error);
+          setAlert(`AI 위험 스캔 실패: ${error.message}`, 'danger');
+        });
+      }
+
+      function exportSchedule() {
+        const header = ['id', 'cargo', 'etd', 'eta', 'status', 'ioi'];
+        const rows = state.schedule.map((voyage) => header.map((key) => voyage[key] ?? '').join(','));
+        const csv = [header.join(','), ...rows].join('\n');
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'schedule-export.csv';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        logEvent('info', '스케줄 CSV 내보내기 완료');
+      }
+
+      buttons.export.addEventListener('click', exportSchedule);
+
+      buttons.quickGo.addEventListener('click', () => {
+        guardedFetch(`${API_BASE}/api/vessel/actions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'quick-go' }),
+        }).then((data) => {
+          setAlert(data.message);
+          logEvent('info', data.message);
+        }).catch((error) => setAlert(`Quick Go 실패: ${error.message}`, 'danger'));
+      });
+
+      buttons.delay.addEventListener('click', () => {
+        guardedFetch(`${API_BASE}/api/vessel/actions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'delay-24h' }),
+        }).then((data) => {
+          setAlert(data.message, 'warn');
+          logEvent('warn', data.message);
+        }).catch((error) => setAlert(`Delay 실패: ${error.message}`, 'danger'));
+      });
+
+      buttons.recalc.addEventListener('click', () => {
+        guardedFetch(`${API_BASE}/api/vessel/actions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'recalculate' }),
+        }).then((data) => {
+          setAlert(data.message);
+          logEvent('info', data.message);
+          refreshMarineSnapshot(true);
+        }).catch((error) => setAlert(`Recalculate 실패: ${error.message}`, 'danger'));
+      });
+
+      buttons.briefing.addEventListener('click', () => {
+        elements.modalContent.textContent = '생성 중...';
+        openModal(elements.briefingModal);
+        const payload = {
+          current_time: state.simulation.now.toISOString(),
+          vessel_name: state.vessel?.name,
+          vessel_status: state.vessel?.status,
+          current_voyage: state.vessel?.currentVoyageId,
+          schedule: state.schedule,
+          weather_windows: state.weatherWindows,
+          model: inputs.assistantModel.value,
+        };
+        fetch(`${API_BASE}/api/briefing`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }).then((res) => {
+          if (!res.ok) throw new Error('Briefing generation failed');
+          return res.json();
+        }).then((data) => {
+          elements.modalContent.innerHTML = data.briefing.replace(/\n/g, '<br>');
+        }).catch((error) => {
+          console.error(error);
+          elements.modalContent.textContent = `Briefing unavailable: ${error.message}`;
+        });
+      });
+
+      if (buttons.dispatchReport) {
+        buttons.dispatchReport.addEventListener('click', () => {
+          buttons.dispatchReport.disabled = true;
+          buttons.dispatchReport.classList.add('opacity-60');
+          guardedFetch(`${API_BASE}/api/report`).then((data) => {
+            applyReportStatus(data?.ok ? 'ok' : 'degraded', data || null);
+            const level = data?.ok ? 'info' : 'warn';
+            const msg = data?.ok ? '일일 리포트 전송 완료' : '일일 리포트 전송 일부 실패';
+            logEvent(level, msg);
+          }).catch((error) => {
+            console.error(error);
+            logEvent('error', `일일 리포트 전송 실패: ${error.message}`);
+            applyReportStatus('degraded', state.lastReport);
+          }).finally(() => {
+            buttons.dispatchReport.disabled = false;
+            buttons.dispatchReport.classList.remove('opacity-60');
+          });
+        });
+      }
+
+      buttons.modalClose.addEventListener('click', () => closeModal(elements.briefingModal));
+
+      buttons.assistantOpen.addEventListener('click', () => openModal(elements.assistantModal));
+      buttons.assistantClose.addEventListener('click', () => closeModal(elements.assistantModal));
+
+      buttons.assistantAttach.addEventListener('click', () => inputs.assistantFile.click());
+      inputs.assistantFile.addEventListener('change', (event) => {
+        addAttachmentsFromFileList(event.target.files || []);
+        event.target.value = '';
+      });
+
+      buttons.assistantReset.addEventListener('click', () => {
+        state.assistantHistory = [];
+        state.pendingAttachments = [];
+        renderAttachments();
+        elements.assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: "다음 3일 스케줄 요약")<br/>첨부 버튼으로 캡처/문서를 추가하면 자동 분석됩니다.</div>';
+        elements.assistantUsage.textContent = '';
+      });
+
+      document.getElementById('assistant-form').addEventListener('submit', (event) => {
+        event.preventDefault();
+        const question = inputs.assistantInput.value.trim();
+        if (!question) return;
+        const userBubble = document.createElement('div');
+        userBubble.className = 'text-right';
+        userBubble.innerHTML = `<span class="bg-purple-800/80 p-2 rounded-lg inline-block">${question}</span>`;
+        elements.assistantConversation.appendChild(userBubble);
+        inputs.assistantInput.value = '';
+        elements.assistantConversation.scrollTop = elements.assistantConversation.scrollHeight;
+        callAssistant(question).then((answer) => {
+          const botBubble = document.createElement('div');
+          botBubble.className = 'text-left';
+          botBubble.innerHTML = `<span class="bg-slate-800 p-2 rounded-lg inline-block">${answer.replace(/\n/g, '<br>')}</span>`;
+          elements.assistantConversation.appendChild(botBubble);
+          elements.assistantConversation.scrollTop = elements.assistantConversation.scrollHeight;
+        }).catch((error) => {
+          const errorBubble = document.createElement('div');
+          errorBubble.className = 'text-left text-rose-300';
+          errorBubble.textContent = error.message;
+          elements.assistantConversation.appendChild(errorBubble);
+        });
+      });
+
+      inputs.fileSchedule.addEventListener('change', (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
         const reader = new FileReader();
         reader.onload = () => {
-          try{
+          try {
             let rows;
-            if(f.name.toLowerCase().endsWith('.json')){
-              const data = JSON.parse(reader.result);
-              if(!Array.isArray(data)) throw new Error('JSON must be an array');
-              rows = data;
+            if (file.name.toLowerCase().endsWith('.json')) {
+              rows = JSON.parse(reader.result);
             } else {
               rows = parseCSV(reader.result);
             }
-            const normalized = rows.map(r=> {
-              const id = r.id || r.Voyage || r.voyage || r.trip || '';
-              const cargo = r.cargo || r.Cargo || '';
-              const etd = r.etd || r.ETD || r.departure || '';
-              const eta = r.eta || r.ETA || r.arrival || '';
-              const status = r.status || r.Status || 'Scheduled';
-              const etdDt = parseISO(etd), etaDt = parseISO(eta);
-              if(!id || !cargo || !etdDt || !etaDt) throw new Error('Missing required fields (id,cargo,etd,eta)');
-              return { id:String(id).trim(), cargo:String(cargo).trim(), etd:fmtIso(etdDt), eta:fmtIso(etaDt), status:String(status).trim() };
+            state.schedule = rows.map((row) => {
+              const id = row.id || row.voyage || row.Voyage;
+              const cargo = row.cargo || row.Cargo;
+              const etd = row.etd || row.ETD;
+              const eta = row.eta || row.ETA;
+              const status = row.status || 'Scheduled';
+              if (!id || !cargo || !etd || !eta) throw new Error('Missing required fields (id,cargo,etd,eta)');
+              return {
+                id: String(id).trim(),
+                cargo: String(cargo).trim(),
+                etd: parseISO(etd)?.toISOString() || new Date().toISOString(),
+                eta: parseISO(eta)?.toISOString() || new Date().toISOString(),
+                status: String(status).trim(),
+                swellFt: safeNumber(row.swellFt ?? row.swell_ft, 3.0),
+                windKt: safeNumber(row.windKt ?? row.wind_kt, 15.0),
+                ioi: safeNumber(row.ioi, 65),
+              };
             });
-            voyageSchedule = normalized.sort((a,b)=> +new Date(a.etd)-+new Date(b.etd));
-            scheduleLabel.textContent = `Loaded: ${f.name}`;
-            setInfo(`스케줄 ${normalized.length}건 로드 완료.`, 'info');
+            labels.schedule.textContent = `Loaded: ${file.name}`;
+            setAlert(`스케줄 ${state.schedule.length}건 로드 완료.`);
             renderSchedule();
-          }catch(err){
-            console.error(err);
-            setInfo(`⚠️ 스케줄 파일 오류: ${err.message}`, 'danger');
+          } catch (error) {
+            console.error(error);
+            setAlert(`⚠️ 스케줄 파일 오류: ${error.message}`, 'danger');
           }
         };
-        reader.readAsText(f);
+        reader.readAsText(file);
       });
 
-      weatherInput.addEventListener('change', (e)=> {
-        if(e.target.files.length===0) return;
-        const f = e.target.files[0];
-        const reader = new FileReader();
-        reader.onload = ()=> {
-          try{
-            const rows = parseCSV(reader.result);
-            buildWeatherWindows(rows);
-            weatherLabel.textContent = `Loaded: ${f.name}`;
-            weatherLinked = true;
-            applyWeatherToSchedule();
-          }catch(err){
-            console.error(err);
-            setInfo(`⚠️ 날씨 파일 오류: ${err.message}`, 'danger');
-          }
-        };
-        reader.readAsText(f);
-      });
-
-      const briefingModal=document.getElementById('briefing-modal');
-      const assistantModal=document.getElementById('assistant-modal');
-      const modalTitle=document.getElementById('modal-title');
-      const modalContent=document.getElementById('modal-content');
-
-      function openModal(el){ 
-        el.classList.remove('opacity-0','pointer-events-none'); 
-        el.setAttribute('aria-hidden', 'false');
-        document.body.classList.add('modal-open'); 
-        // Focus management
-        const focusableElements = el.querySelectorAll('button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
-        if(focusableElements.length > 0) {
-          focusableElements[0].focus();
-        }
-      }
-      function closeModal(el){ 
-        el.classList.add('opacity-0','pointer-events-none'); 
-        el.setAttribute('aria-hidden', 'true');
-        document.body.classList.remove('modal-open'); 
-      }
-      [briefingModal,assistantModal].forEach(m=> m.addEventListener('click', e=>{ if(e.target===m) closeModal(m); }));
-      document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ [briefingModal,assistantModal].forEach(closeModal); } });
-
-      function renderAttachmentList(){
-        if(pendingAttachments.length===0){
-          assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
+      inputs.fileWeather.addEventListener('change', (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        const isImage = (file.type && file.type.startsWith('image/')) || /\.(png|jpg|jpeg|webp|gif)$/i.test(file.name);
+        if (isImage) {
+          labels.weather.textContent = 'Analyzing screenshot...';
+          labels.weather.classList.add('animate-pulse');
+          callAssistant('weather insight from screenshot', { attachments: [file], persist: false }).then((answer) => {
+            elements.analysisContent.innerHTML = answer.replace(/\n/g, '<br>');
+            elements.analysisPanel.classList.remove('hidden');
+            setAlert('스크린샷 분석 완료. 리스크 모니터링 활성화.', 'warn');
+          }).catch((error) => {
+            console.error(error);
+            elements.analysisPanel.classList.add('hidden');
+            elements.analysisContent.textContent = '';
+            setAlert(`⚠️ 스크린샷 분석 실패: ${error.message}`, 'danger');
+          }).finally(() => {
+            labels.weather.classList.remove('animate-pulse');
+            labels.weather.textContent = `Loaded: ${file.name}`;
+          });
           return;
         }
-        assistantAttachments.innerHTML = pendingAttachments.map((file,idx)=> {
-          return `<div class="flex justify-between items-center bg-slate-900/80 px-2 py-1 rounded">
-                    <span class="truncate max-w-[14rem]">${file.name}</span>
-                    <button data-index="${idx}" class="text-rose-300 hover:text-rose-400 remove-attachment">Remove</button>
-                  </div>`;
-        }).join('');
-        assistantAttachments.querySelectorAll('.remove-attachment').forEach(btn=> {
-          btn.addEventListener('click',(ev)=> {
-            const idx = Number(ev.target.getAttribute('data-index'));
-            pendingAttachments.splice(idx,1);
-            renderAttachmentList();
-          });
-        });
-      }
-
-      assistantAttachments.innerHTML = '<div class="text-slate-500">No attachments selected.</div>';
-
-      document.getElementById('assistant-attach-btn').addEventListener('click', ()=> assistantFileInput.click());
-      assistantFileInput.addEventListener('change', (event)=> {
-        pendingAttachments = Array.from(event.target.files || []);
-        renderAttachmentList();
-      });
-
-      document.getElementById('assistant-reset').addEventListener('click', ()=> {
-        assistantHistory = [];
-        assistantConversation.innerHTML = '<div class="text-slate-400">무엇을 도와드릴까요? (예: “다음 3일 스케줄 요약”)</div>';
-        assistantUsage.textContent='';
-      });
-
-      async function callAssistant(prompt, attachments){
-        const formData = new FormData();
-        formData.append('prompt', prompt);
-        formData.append('history', JSON.stringify(assistantHistory));
-        formData.append('model', assistantModelSelect.value);
-        attachments.forEach(file=> formData.append('files', file, file.name));
-        const res = await fetch(`${API_BASE}/api/assistant`, { method:'POST', body: formData });
-        if(!res.ok){
-          const text = await res.text();
-          throw new Error(text || 'Assistant call failed');
-        }
-        const data = await res.json();
-        assistantHistory.push({role:'user', content: prompt});
-        assistantHistory.push({role:'assistant', content: data.answer});
-        assistantUsage.textContent = `Last response model: ${assistantModelSelect.value}`;
-        return data.answer;
-      }
-
-      async function fetchBriefing(){
-        modalTitle.textContent = '✨ Daily Briefing';
-        modalContent.innerHTML = '생성 중...';
-        openModal(briefingModal);
-        const payload = {
-          current_time: currentSimDate.toISOString(),
-          vessel_name: vesselData.name,
-          vessel_status: vesselData.status,
-          current_voyage: vesselData.currentVoyageId,
-          schedule: voyageSchedule,
-          weather_windows: weatherWindows.map(w=>({
-            start: w.start ? w.start.toISOString?.() || w.start : w.start,
-            end: w.end ? w.end.toISOString?.() || w.end : w.end,
-            level: w.level,
-            waveM: w.waveM,
-            windKt: w.windKt,
-            visKm: w.visKm
-          }))
-        };
-        try{
-          const res = await fetch(`${API_BASE}/api/briefing`, {
-            method:'POST',
-            headers:{'Content-Type':'application/json'},
-            body: JSON.stringify(payload)
-          });
-          if(!res.ok) throw new Error(await res.text());
-          const data = await res.json();
-          modalContent.innerHTML = data.briefing.replace(/\n/g,'<br>');
-        }catch(err){
-          console.error(err);
-          const cur = voyageSchedule.find(v=>v.id===vesselData.currentVoyageId);
-          const fallback = `현재 시각 ${toLocal(currentSimDate)}.\n진행 항차: ${cur?.id || 'N/A'} / 화물: ${cur?.cargo || 'N/A'} / 상태: ${vesselData.status}.`;
-          modalContent.innerHTML = `${fallback.replace(/\n/g,'<br>')}<br><br><span class="text-rose-300">AI Briefing unavailable: ${err.message}</span>`;
-        }
-      }
-
-      async function runRiskScan(){
-        const prompt = `다음 일정과 기상창을 기반으로 3가지 위험 시나리오와 대응 권고를 bullet로 정리해줘.\n일정: ${JSON.stringify(voyageSchedule)}\n기상: ${JSON.stringify(weatherWindows)}`;
-        setInfo('AI 위험 스캔 실행 중...', 'info');
-        try{
-          const answer = await callAssistant(prompt, []);
-          setInfo(answer.replace(/\n/g,'<br>'), 'warn');
-        }catch(err){
-          setInfo(`AI 위험 스캔 실패: ${err.message}`, 'danger');
-        }
-      }
-
-      document.getElementById('briefing-btn').addEventListener('click', fetchBriefing);
-      document.getElementById('btn-ai-risk').addEventListener('click', runRiskScan);
-      document.getElementById('close-modal-btn').addEventListener('click', ()=>closeModal(briefingModal));
-      document.getElementById('assistant-btn').addEventListener('click', ()=>openModal(assistantModal));
-      document.getElementById('close-assistant-btn').addEventListener('click', ()=>closeModal(assistantModal));
-
-      document.getElementById('assistant-form').addEventListener('submit', async (e)=> {
-        e.preventDefault();
-        const input=document.getElementById('assistant-input');
-        const q=input.value.trim(); if(!q) return;
-        assistantConversation.innerHTML += `<div class="text-right"><span class="bg-purple-800/80 p-2 rounded-lg inline-block">${q}</span></div>`;
-        input.value='';
-        assistantConversation.scrollTop=assistantConversation.scrollHeight;
-        try{
-          const ans = await callAssistant(q, pendingAttachments);
-          assistantConversation.innerHTML += `<div class="text-left"><span class="bg-slate-800 p-2 rounded-lg inline-block">${ans.replace(/\n/g,'<br>')}</span></div>`;
-          assistantConversation.scrollTop=assistantConversation.scrollHeight;
-          pendingAttachments = [];
-          assistantFileInput.value = '';
-          renderAttachmentList();
-        }catch(err){
-          assistantConversation.innerHTML += `<div class="text-left text-rose-300">${err.message}</div>`;
-          assistantConversation.scrollTop=assistantConversation.scrollHeight;
-        }
-      });
-
-      document.getElementById('btn-reset').addEventListener('click', ()=> {
-        currentSimDate = new Date("2025-09-28T12:00:00Z");
-        vesselData.currentVoyageId = null;
-        vesselData.status = "Ready @ MW4";
-        setInfo('시뮬레이션 시계가 초기화되었습니다.');
-      });
-
-      // Marine data functions
-      async function updateMarineForLeg(portName) {
-        // 워커로 오프로드
-        const snap = await fetchMarineAndIOIInWorker(portName);
-        if (snap && snap.hs != null && snap.windKt != null) {
-          marineBadge.textContent = `Hs: ${snap.hs.toFixed(2)} m · Wind: ${Math.round(snap.windKt)} kt`;
-        } else {
-          marineBadge.textContent = `Marine: n/a`;
-        }
-        return snap;
-      }
-
-      // ===== Worker 생성 (Blob URL) : IOI 계산 + Marine fetch 오프로드 =====
-      const workerCode = `
-        self.addEventListener('message', async (e) => {
-          const { type, payload } = e.data || {};
-          if (type === 'marine+ioi') {
-            const { port, coords, RULE } = payload;
-            try {
-              const params = new URLSearchParams({
-                latitude: String(coords.lat),
-                longitude: String(coords.lon),
-                hourly: ['wave_height','wind_speed_10m','swell_wave_period'].join(','),
-                timezone: 'auto'
-              });
-              const url = 'https://marine-api.open-meteo.com/v1/marine?' + params.toString();
-              const r = await fetch(url);
-              const j = await r.json();
-              const idx = 0;
-              const hs = j?.hourly?.wave_height?.[idx] ?? null;
-              const wsms = j?.hourly?.wind_speed_10m?.[idx] ?? null;
-              const sp = j?.hourly?.swell_wave_period?.[idx] ?? null;
-              const windKt = wsms != null ? (wsms * 1.94384) : null;
-              // IOI 계산 (워커쪽 동일 로직)
-              function ioiCalc(hs, windKt, sp, RULE){
-                const hsScore = (hs==null)?0.5:(hs<=RULE.hs_caution?1:hs>=RULE.hs_nogo?0:1-((hs-RULE.hs_caution)/(RULE.hs_nogo-RULE.hs_caution)));
-                const wScore  = (windKt==null)?0.5:(windKt<=RULE.wind_caution?1:windKt>=RULE.wind_nogo?0:1-((windKt-RULE.wind_caution)/(RULE.wind_nogo-RULE.wind_caution)));
-                const spMin=6, spMax=12; const s = Math.max(spMin, Math.min(spMax, (sp ?? 8)));
-                const swellScore = (s-spMin)/(spMax-spMin);
-                const score = 0.5*hsScore + 0.35*wScore + 0.15*swellScore;
-                return Math.round(score*100);
-              }
-              const ioi = ioiCalc(hs, windKt, sp, RULE);
-              self.postMessage({ type:'marine+ioi:done', payload:{ port, hs, windKt, sp, ioi }});
-            } catch (err) {
-              self.postMessage({ type:'marine+ioi:error', payload:{ port, error: String(err) }});
-            }
+        const reader = new FileReader();
+        reader.onload = () => {
+          try {
+            const rows = parseCSV(reader.result);
+            state.weatherWindows = rows.map((row) => ({
+              start: row.start || row.Start,
+              end: row.end || row.End,
+              wave_m: safeNumber(row.wave_m ?? row.wave, 1.2),
+              wind_kt: safeNumber(row.wind_kt ?? row.wind, 15.0),
+              vis_km: safeNumber(row.vis_km ?? row.visibility, 10.0),
+              summary: row.summary || row.note || 'Imported window',
+            }));
+            labels.weather.textContent = `Loaded: ${file.name}`;
+            state.weatherLinked = inputs.toggleWeather.checked;
+            applyWeatherWindows();
+            renderSchedule();
+          } catch (error) {
+            console.error(error);
+            setAlert(`⚠️ 날씨 파일 오류: ${error.message}`, 'danger');
           }
-        });
-      `;
-      const workerUrl = URL.createObjectURL(new Blob([workerCode], {type:'text/javascript'}));
-      const marineWorker = new Worker(workerUrl, { type:'module' });
-      const pendingIOI = new Map(); // port -> Promise resolvers
-      marineWorker.addEventListener('message', (e)=> {
-        const { type, payload } = e.data || {};
-        if (type === 'marine+ioi:done') {
-          const { port, hs, windKt, sp, ioi } = payload;
-          const resolver = pendingIOI.get(port);
-          if (resolver) { resolver.resolve({ hs, windKt, swellPeriod: sp, ioi }); pendingIOI.delete(port); }
-        } else if (type === 'marine+ioi:error') {
-          const resolver = pendingIOI.get(payload.port);
-          if (resolver) { resolver.resolve(null); pendingIOI.delete(payload.port); }
+        };
+        reader.readAsText(file);
+      });
+
+      inputs.toggleWeather.addEventListener('change', (event) => {
+        state.weatherLinked = event.target.checked;
+        applyWeatherWindows();
+      });
+
+      buttons.aiRisk.addEventListener('click', runRiskScan);
+      buttons.resetSim.addEventListener('click', resetSimulation);
+
+      elements.assistantDropzone.addEventListener('dragenter', (event) => {
+        event.preventDefault();
+        elements.assistantDropzone.classList.add('drop-active');
+      });
+      elements.assistantDropzone.addEventListener('dragover', (event) => {
+        event.preventDefault();
+      });
+      elements.assistantDropzone.addEventListener('dragleave', () => {
+        elements.assistantDropzone.classList.remove('drop-active');
+      });
+      elements.assistantDropzone.addEventListener('drop', (event) => {
+        event.preventDefault();
+        elements.assistantDropzone.classList.remove('drop-active');
+        addAttachmentsFromFileList(event.dataTransfer?.files || []);
+      });
+
+      document.addEventListener('paste', (event) => {
+        if (elements.assistantModal.getAttribute('aria-hidden') === 'true') return;
+        const items = event.clipboardData?.items || [];
+        const files = [];
+        for (const item of items) {
+          if (item.kind === 'file') {
+            const file = item.getAsFile();
+            if (file) files.push(file);
+          }
+        }
+        if (files.length) {
+          event.preventDefault();
+          addAttachmentsFromFileList(files);
         }
       });
-      function fetchMarineAndIOIInWorker(portName) {
-        const coords = portCoords[portName];
-        if (!coords) return Promise.resolve(null);
-        return new Promise((resolve)=> {
-          pendingIOI.set(portName, { resolve });
-          marineWorker.postMessage({ type:'marine+ioi', payload: { port: portName, coords, RULE }});
 
+      function bootstrap() {
+        checkApiHealth();
+        guardedFetch(`${API_BASE}/api/vessel`).then((dataset) => {
+          populateFromDataset(dataset);
+          refreshMarineSnapshot().then(() => startMarineAutoRefresh());
+          startSimulationLoop();
+          setAlert('대시보드가 초기화되었습니다.');
+        }).catch((error) => {
+          console.error(error);
+          setAlert(`데이터 로드 실패: ${error.message}`, 'danger');
         });
       }
+
+      bootstrap();
     });
   </script>
 </body>

--- a/scripts/scheduler.ts
+++ b/scripts/scheduler.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// @ts-nocheck
+/* eslint-disable no-console */
+const cron = require('node-cron')
+const fs = require('fs/promises')
+const path = require('path')
+
+const TIMEZONE = process.env.REPORT_TIMEZONE || 'Asia/Dubai'
+const ENDPOINT = process.env.REPORT_ENDPOINT || 'http://localhost:3000/api/report'
+const LOCK_PATH = path.resolve(process.env.REPORT_LOCK_FILE || '.weather-vessel-report.lock')
+const LOCK_TTL_MS = 10 * 60 * 1000
+
+/**
+ * @typedef {Record<string, string>} LockMap
+ */
+
+/** @returns {Promise<LockMap>} */
+async function readLock() {
+  try {
+    const raw = await fs.readFile(LOCK_PATH, 'utf8')
+    return JSON.parse(raw)
+  } catch (error) {
+    return {}
+  }
+}
+
+/** @param {LockMap} lock */
+async function writeLock(lock) {
+  await fs.writeFile(LOCK_PATH, JSON.stringify(lock, null, 2))
+}
+
+/**
+ * @param {LockMap} lock
+ * @param {"am"|"pm"} slot
+ */
+async function shouldSkip(lock, slot) {
+  const entry = lock[slot]
+  if (!entry) return false
+  const last = new Date(entry)
+  if (Number.isNaN(last.valueOf())) return false
+  return Date.now() - last.valueOf() < LOCK_TTL_MS
+}
+
+/** @param {"am"|"pm"} slot */
+async function triggerReport(slot) {
+  const lock = await readLock()
+  if (await shouldSkip(lock, slot)) {
+    console.log(`[scheduler] ${slot} report skipped (recent execution)`)
+    return
+  }
+
+  lock[slot] = new Date().toISOString()
+  await writeLock(lock)
+
+  const url = `${ENDPOINT}?slot=${slot}`
+  console.log(`[scheduler] Dispatching ${slot.toUpperCase()} report via ${url}`)
+  try {
+    const response = await fetch(url)
+    const payload = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      console.error(`[scheduler] Report dispatch failed: HTTP ${response.status}`, payload)
+      return
+    }
+    if (payload?.ok) {
+      const summary = Array.isArray(payload.sent)
+        ? /** @type {{ channel: string; ok: boolean }[]} */ (payload.sent).map(
+            (item) => `${item.channel}:${item.ok ? 'ok' : 'err'}`,
+          ).join(', ')
+        : 'no-summary'
+      console.log(`[scheduler] Report sent successfully (${summary})`)
+    } else {
+      console.warn('[scheduler] Report responded with partial failure', payload)
+    }
+  } catch (error) {
+    console.error('[scheduler] Report dispatch error', error)
+  }
+}
+
+console.log(`[scheduler] Starting with timezone ${TIMEZONE} targeting ${ENDPOINT}`)
+
+cron.schedule('0 6 * * *', () => triggerReport('am'), { timezone: TIMEZONE })
+cron.schedule('0 17 * * *', () => triggerReport('pm'), { timezone: TIMEZONE })
+
+console.log('[scheduler] Schedules registered for 06:00 and 17:00 local time')
+
+triggerReport('am').catch((error) => console.error('[scheduler] Initial trigger failed', error))
+
+process.on('SIGINT', () => {
+  console.log('\n[scheduler] Stopping')
+  process.exit(0)
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "crons": [
+    { "path": "/api/report?slot=am", "schedule": "0 2 * * *" },
+    { "path": "/api/report?slot=pm", "schedule": "0 13 * * *" }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,25 @@
+import path from "node:path"
+
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["lib/server/**/*.ts", "app/api/report/route.ts"],
+      thresholds: {
+        lines: 70,
+        statements: 70,
+      },
+    },
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add notifier utilities for Slack and Resend along with shared report state tracking
- implement /api/report endpoint plus health telemetry and vitest coverage for reporting flows
- surface report status in the dashboard, document configuration, and add cron scheduling for Vercel and self-host

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint` *(fails: command prompts for interactive ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d973e360248327bd546c2e6ca422a1